### PR TITLE
Rename palette module to MSX1PQPalettes

### DIFF
--- a/platform/Win/MSX1PaletteQuantizer.vcxproj
+++ b/platform/Win/MSX1PaletteQuantizer.vcxproj
@@ -113,7 +113,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(AESDK_ROOT)Headers;$(AESDK_ROOT)Headers\SP;$(AESDK_ROOT)Headers\Win;$(AESDK_ROOT)Resources;$(AESDK_ROOT)Util;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(AESDK_ROOT)Headers;$(AESDK_ROOT)Headers\SP;$(AESDK_ROOT)Headers\Win;$(AESDK_ROOT)Resources;$(AESDK_ROOT)Util;$(ProjectDir)..\..\src\core;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MSWindows;WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <StructMemberAlignment>
@@ -167,7 +167,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(AESDK_ROOT)Headers;$(AESDK_ROOT)Headers\SP;$(AESDK_ROOT)Headers\Win;$(AESDK_ROOT)Resources;$(AESDK_ROOT)Util;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(AESDK_ROOT)Headers;$(AESDK_ROOT)Headers\SP;$(AESDK_ROOT)Headers\Win;$(AESDK_ROOT)Resources;$(AESDK_ROOT)Util;$(ProjectDir)..\..\src\core;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MSWindows;WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <StructMemberAlignment>
@@ -222,7 +222,7 @@
     </Midl>
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
-      <AdditionalIncludeDirectories>$(AESDK_ROOT)Headers;$(AESDK_ROOT)Headers\SP;$(AESDK_ROOT)Headers\Win;$(AESDK_ROOT)Resources;$(AESDK_ROOT)Util;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(AESDK_ROOT)Headers;$(AESDK_ROOT)Headers\SP;$(AESDK_ROOT)Headers\Win;$(AESDK_ROOT)Resources;$(AESDK_ROOT)Util;$(ProjectDir)..\..\src\core;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MSWindows;WIN32;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <StructMemberAlignment>Default</StructMemberAlignment>
@@ -276,7 +276,7 @@
     </Midl>
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
-      <AdditionalIncludeDirectories>$(AESDK_ROOT)Headers;$(AESDK_ROOT)Headers\SP;$(AESDK_ROOT)Headers\Win;$(AESDK_ROOT)Resources;$(AESDK_ROOT)Util;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(AESDK_ROOT)Headers;$(AESDK_ROOT)Headers\SP;$(AESDK_ROOT)Headers\Win;$(AESDK_ROOT)Resources;$(AESDK_ROOT)Util;$(ProjectDir)..\..\src\core;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MSWindows;WIN32;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <StructMemberAlignment>Default</StructMemberAlignment>
@@ -322,7 +322,7 @@
     <ClInclude Include="$(AESDK_ROOT)Headers\AEFX_SuiteHandlerTemplate.h" />
     <ClInclude Include="$(AESDK_ROOT)Headers\AE_PluginData.h" />
     <ClInclude Include="..\..\src\ae\MSX1PaletteQuantizer.h" />
-    <ClInclude Include="..\..\src\ae\MSX1PaletteQuantizerPalettes.h" />
+    <ClInclude Include="..\..\src\core\MSX1PQPalettes.h" />
     <ClInclude Include="$(AESDK_ROOT)Util\Smart_Utils.h" />
     <ClInclude Include="$(AESDK_ROOT)Util\String_Utils.h" />
     <ClInclude Include="$(AESDK_ROOT)Headers\A.h" />
@@ -381,7 +381,7 @@ cl /D "MSWindows" /EP $(IntDir)%(Filename).rrc &gt;               "$(ProjectDir)
   <ItemGroup>
     <ClCompile Include="$(AESDK_ROOT)Util\Smart_Utils.cpp" />
     <ClCompile Include="..\..\src\ae\MSX1PaletteQuantizer.cpp" />
-    <ClCompile Include="..\..\src\ae\MSX1PaletteQuantizerPalettes.cpp" />
+    <ClCompile Include="..\..\src\core\MSX1PQPalettes.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -14,7 +14,7 @@
 #include "AEFX_SuiteHelper.h"
 #include "AEGP_SuiteHandler.h"
 #include "MSX1PaletteQuantizer.h"
-#include "MSX1PaletteQuantizerPalettes.h"
+#include "MSX1PQPalettes.h"
 
 
 #ifdef AE_OS_WIN
@@ -1451,7 +1451,10 @@ FilterImage8 (
                 num_colors);
         }
 
-        basic_idx = MSX1PQ::palette_index_to_basic_index(palette_idx, xL, yL);
+        basic_idx = MSX1PQ::palette_index_to_basic_index(
+            palette_idx,
+            static_cast<std::int32_t>(xL),
+            static_cast<std::int32_t>(yL));
     } else {
         // ディザOFF: 直接15色へ
         if (qi && qi->use_hsb) {
@@ -1519,7 +1522,10 @@ FilterImageBGRA_8u (
                 num_colors);
         }
 
-        basic_idx = MSX1PQ::palette_index_to_basic_index(palette_idx, xL, yL);
+        basic_idx = MSX1PQ::palette_index_to_basic_index(
+            palette_idx,
+            static_cast<std::int32_t>(xL),
+            static_cast<std::int32_t>(yL));
     } else {
         if (qi && qi->use_hsb) {
             basic_idx = nearest_basic_hsb(

--- a/src/core/MSX1PQPalettes.cpp
+++ b/src/core/MSX1PQPalettes.cpp
@@ -1,4 +1,4 @@
-#include "MSX1PaletteQuantizerPalettes.h"
+#include "MSX1PQPalettes.h"
 #include <limits.h>
 
 const MSX1PQ::QuantColor MSX1PQ::kQuantColors[] = {
@@ -138,35 +138,35 @@ const int MSX1PQ::kFirstDarkDitherIndex = MSX1PQ::kNumQuantColors - MSX1PQ::kNum
 
 // ---- ディザパターン生成マクロ ----
 #define MAKE_LINE_PATTERN(NAME, COL1_ID, COL2_ID) \
-    static const A_u_char NAME[] = { \
-        (A_u_char)((COL1_ID) - 1), \
-        (A_u_char)((COL2_ID) - 1)  \
+    static const std::uint8_t NAME[] = { \
+        (std::uint8_t)((COL1_ID) - 1), \
+        (std::uint8_t)((COL2_ID) - 1)  \
     }
 
 #define MAKE_DARK_PATTERN(NAME, COL1_ID, COL2_ID) \
-    static const A_u_char NAME[] = { \
-        (A_u_char)((COL1_ID) - 1), (A_u_char)((COL1_ID) - 1), \
-        (A_u_char)((COL1_ID) - 1), (A_u_char)((COL2_ID) - 1), \
-        (A_u_char)((COL1_ID) - 1), (A_u_char)((COL1_ID) - 1), \
-        (A_u_char)((COL2_ID) - 1), (A_u_char)((COL1_ID) - 1)  \
+    static const std::uint8_t NAME[] = { \
+        (std::uint8_t)((COL1_ID) - 1), (std::uint8_t)((COL1_ID) - 1), \
+        (std::uint8_t)((COL1_ID) - 1), (std::uint8_t)((COL2_ID) - 1), \
+        (std::uint8_t)((COL1_ID) - 1), (std::uint8_t)((COL1_ID) - 1), \
+        (std::uint8_t)((COL2_ID) - 1), (std::uint8_t)((COL1_ID) - 1)  \
     }
 
 // 基本15色の 1x1 パターン (id 1..15 → index 0..14)
-static const A_u_char kPattern_basic_1[]  = {  0 };
-static const A_u_char kPattern_basic_2[]  = {  1 };
-static const A_u_char kPattern_basic_3[]  = {  2 };
-static const A_u_char kPattern_basic_4[]  = {  3 };
-static const A_u_char kPattern_basic_5[]  = {  4 };
-static const A_u_char kPattern_basic_6[]  = {  5 };
-static const A_u_char kPattern_basic_7[]  = {  6 };
-static const A_u_char kPattern_basic_8[]  = {  7 };
-static const A_u_char kPattern_basic_9[]  = {  8 };
-static const A_u_char kPattern_basic_10[] = {  9 };
-static const A_u_char kPattern_basic_11[] = { 10 };
-static const A_u_char kPattern_basic_12[] = { 11 };
-static const A_u_char kPattern_basic_13[] = { 12 };
-static const A_u_char kPattern_basic_14[] = { 13 };
-static const A_u_char kPattern_basic_15[] = { 14 };
+static const std::uint8_t kPattern_basic_1[]  = {  0 };
+static const std::uint8_t kPattern_basic_2[]  = {  1 };
+static const std::uint8_t kPattern_basic_3[]  = {  2 };
+static const std::uint8_t kPattern_basic_4[]  = {  3 };
+static const std::uint8_t kPattern_basic_5[]  = {  4 };
+static const std::uint8_t kPattern_basic_6[]  = {  5 };
+static const std::uint8_t kPattern_basic_7[]  = {  6 };
+static const std::uint8_t kPattern_basic_8[]  = {  7 };
+static const std::uint8_t kPattern_basic_9[]  = {  8 };
+static const std::uint8_t kPattern_basic_10[] = {  9 };
+static const std::uint8_t kPattern_basic_11[] = { 10 };
+static const std::uint8_t kPattern_basic_12[] = { 11 };
+static const std::uint8_t kPattern_basic_13[] = { 12 };
+static const std::uint8_t kPattern_basic_14[] = { 13 };
+static const std::uint8_t kPattern_basic_15[] = { 14 };
 
 // ---- line_dithering 用 (dith_col2 のペア全部) ----
 MAKE_LINE_PATTERN(kPattern_1_4,   1,  4);
@@ -377,7 +377,7 @@ const int MSX1PQ::kNumPaletteDither =
 
 // ---- MSX1PQ::palette_index_to_basic_index ----
 int
-MSX1PQ::palette_index_to_basic_index(int palette_idx, A_long xL, A_long yL)
+MSX1PQ::palette_index_to_basic_index(int palette_idx, std::int32_t xL, std::int32_t yL)
 {
     if (palette_idx < 0) {
         palette_idx = 0;
@@ -399,13 +399,13 @@ MSX1PQ::palette_index_to_basic_index(int palette_idx, A_long xL, A_long yL)
         }
     }
 
-    A_long ix = (xL >= 0) ? xL : -xL;
-    A_long iy = (yL >= 0) ? yL : -yL;
+    std::int32_t ix = (xL >= 0) ? xL : -xL;
+    std::int32_t iy = (yL >= 0) ? yL : -yL;
 
-    A_long dx = ix % dp->width;
-    A_long dy = iy % dp->height;
+    std::int32_t dx = ix % dp->width;
+    std::int32_t dy = iy % dp->height;
 
-    A_long idx = dy * dp->width + dx;
+    std::int32_t idx = dy * dp->width + dx;
 
     int basic_idx = dp->pattern[idx]; // 0..14
     if (basic_idx < 0) basic_idx = 0;
@@ -416,7 +416,7 @@ MSX1PQ::palette_index_to_basic_index(int palette_idx, A_long xL, A_long yL)
 
 // ---- ディザ無し用 最近傍 basic15 ----
 int
-MSX1PQ::nearest_basic_rgb(A_u_char r, A_u_char g, A_u_char b)
+MSX1PQ::nearest_basic_rgb(std::uint8_t r, std::uint8_t g, std::uint8_t b)
 {
     int  best_idx  = 0;
     long best_dist = LONG_MAX;

--- a/src/core/MSX1PQPalettes.h
+++ b/src/core/MSX1PQPalettes.h
@@ -1,21 +1,20 @@
 #pragma once
 
-#include "AEConfig.h"
-#include "AE_Effect.h"
+#include <cstdint>
 
 namespace MSX1PQ {
     // MSX1 カラー1つ分
     typedef struct {
-        A_u_char r;
-        A_u_char g;
-        A_u_char b;
+        std::uint8_t r;
+        std::uint8_t g;
+        std::uint8_t b;
     } QuantColor;
 
     // ディザパターン
     typedef struct {
-        const A_u_char* pattern; // 長さ = width * height, 値は 0..14 (基本15色インデックス)
-        A_u_char        width;
-        A_u_char        height;
+        const std::uint8_t* pattern; // 長さ = width * height, 値は 0..14 (基本15色インデックス)
+        std::uint8_t        width;
+        std::uint8_t        height;
     } DitherPattern;
 
     // パレット配列 (MSX1基本色 + ディザ中間色 + 低輝度パレット)
@@ -30,10 +29,10 @@ namespace MSX1PQ {
     extern const int           kNumPaletteDither;
 
     // パレットインデックス＋座標 → 基本15色インデックス
-    int palette_index_to_basic_index(int palette_idx, A_long xL, A_long yL);
+    int palette_index_to_basic_index(int palette_idx, std::int32_t x, std::int32_t y);
 
     // ディザなし用：RGB → 基本15色インデックス
-    int nearest_basic_rgb(A_u_char r, A_u_char g, A_u_char b);
+    int nearest_basic_rgb(std::uint8_t r, std::uint8_t g, std::uint8_t b);
 
     // 低輝度ディザパレットの範囲
     extern const int kNumDarkDitherColors;   // 例: 6


### PR DESCRIPTION
## Summary
- rename the core palette header/source pair to MSX1PQPalettes
- update AE plugin source to include the renamed header
- point the Windows project file at the new palette filenames

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927523972a883249cb2d4a214a55563)