### PR TITLE
Align PiPL version with packed version

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -42,7 +42,7 @@ namespace MSX1PQ {
     constexpr char kPluginName[]        = "MSX1 Palette Quantizer";
     constexpr char kPluginDescription[] = "\nMSX1-style palette quantization and dithering.";
     constexpr int  kVersionMajor        = 0;
-    constexpr int  kVersionMinor        = 2;
+    constexpr int  kVersionMinor        = 3;
     constexpr int  kVersionBug          = 0;
     constexpr int  kVersionStage        = PF_Stage_ALPHA;
     /*

--- a/src/ae/MSX1PaletteQuantizerPiPL.r
+++ b/src/ae/MSX1PaletteQuantizerPiPL.r
@@ -34,12 +34,12 @@ resource 'PiPL' (16000) {
 			PF_PLUG_IN_VERSION,
 			PF_PLUG_IN_SUBVERS
 		},
-		AE_Effect_Version {
-			66049
+                AE_Effect_Version {
+                        98817
             /*
             You can also calculate it as follows to match the specified values in the GlobalSetup function.
             (ST =  0:dev 1:alpha 2:beta 3:release)
-            python -c "import sys;M,S,B,ST,BL=map(int,sys.argv[1:]);print(((M>>3)&15)<<26 | (M&7)<<19 | (S&15)<<15 | (B&15)<<11 | (ST&3)<<9 | (BL&0x1FF))" 0 2 0 1 1
+            python -c "import sys;M,S,B,ST,BL=map(int,sys.argv[1:]);print(((M>>3)&15)<<26 | (M&7)<<19 | (S&15)<<15 | (B&15)<<11 | (ST&3)<<9 | (BL&0x1FF))" 0 3 0 1 1
             */
 		},
 		AE_Effect_Info_Flags {


### PR DESCRIPTION
## Summary
- update AE_Effect_Version in the PiPL resource to match the packed plugin version
- adjust the example command to reflect the current version numbers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69276e3e6aec8324874ec87a33a0ce69)