### PR TITLE
Add CLI PNG quantizer tool

### DIFF
--- a/src/cui/lodepng.cpp
+++ b/src/cui/lodepng.cpp
@@ -1,0 +1,145 @@
+#include "lodepng.h"
+
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+
+#include <png.h>
+
+namespace lodepng {
+
+namespace {
+
+const char* error_message(unsigned code) {
+    switch (code) {
+    case 0:  return "no error";
+    case 1:  return "failed to open file";
+    case 2:  return "failed to initialize png reader";
+    case 3:  return "failed to read png";
+    case 4:  return "failed to initialize png writer";
+    case 5:  return "failed to write png";
+    default: return "unknown error";
+    }
+}
+
+}
+
+const char* lodepng_error_text(unsigned code) {
+    return error_message(code);
+}
+
+unsigned decode(std::vector<unsigned char>& out, unsigned& w, unsigned& h, const std::string& filename) {
+    FILE* fp = std::fopen(filename.c_str(), "rb");
+    if (!fp) {
+        return 1;
+    }
+
+    png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+    if (!png_ptr) {
+        std::fclose(fp);
+        return 2;
+    }
+
+    png_infop info_ptr = png_create_info_struct(png_ptr);
+    if (!info_ptr) {
+        png_destroy_read_struct(&png_ptr, nullptr, nullptr);
+        std::fclose(fp);
+        return 2;
+    }
+
+    if (setjmp(png_jmpbuf(png_ptr))) {
+        png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+        std::fclose(fp);
+        return 3;
+    }
+
+    png_init_io(png_ptr, fp);
+    png_read_info(png_ptr, info_ptr);
+
+    png_uint_32 width = 0, height = 0;
+    int bit_depth = 0, color_type = 0;
+    png_get_IHDR(png_ptr, info_ptr, &width, &height, &bit_depth, &color_type, nullptr, nullptr, nullptr);
+
+    png_set_expand(png_ptr);
+    if (bit_depth == 16) {
+        png_set_strip_16(png_ptr);
+    }
+    png_set_gray_to_rgb(png_ptr);
+    if (!(color_type & PNG_COLOR_MASK_ALPHA)) {
+        png_set_add_alpha(png_ptr, 0xFF, PNG_FILLER_AFTER);
+    }
+    png_set_palette_to_rgb(png_ptr);
+
+    png_read_update_info(png_ptr, info_ptr);
+
+    w = width;
+    h = height;
+    out.resize(static_cast<size_t>(w) * static_cast<size_t>(h) * 4);
+
+    std::vector<png_bytep> row_pointers(h);
+    for (png_uint_32 y = 0; y < h; ++y) {
+        row_pointers[y] = reinterpret_cast<png_bytep>(&out[y * w * 4]);
+    }
+
+    png_read_image(png_ptr, row_pointers.data());
+    png_read_end(png_ptr, info_ptr);
+
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+    std::fclose(fp);
+    return 0;
+}
+
+unsigned encode(const std::string& filename, const std::vector<unsigned char>& image, unsigned w, unsigned h) {
+    FILE* fp = std::fopen(filename.c_str(), "wb");
+    if (!fp) {
+        return 1;
+    }
+
+    png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+    if (!png_ptr) {
+        std::fclose(fp);
+        return 4;
+    }
+
+    png_infop info_ptr = png_create_info_struct(png_ptr);
+    if (!info_ptr) {
+        png_destroy_write_struct(&png_ptr, nullptr);
+        std::fclose(fp);
+        return 4;
+    }
+
+    if (setjmp(png_jmpbuf(png_ptr))) {
+        png_destroy_write_struct(&png_ptr, &info_ptr);
+        std::fclose(fp);
+        return 5;
+    }
+
+    png_init_io(png_ptr, fp);
+    png_set_IHDR(
+        png_ptr,
+        info_ptr,
+        w,
+        h,
+        8,
+        PNG_COLOR_TYPE_RGBA,
+        PNG_INTERLACE_NONE,
+        PNG_COMPRESSION_TYPE_DEFAULT,
+        PNG_FILTER_TYPE_DEFAULT);
+
+    png_write_info(png_ptr, info_ptr);
+
+    std::vector<png_bytep> row_pointers(h);
+    for (png_uint_32 y = 0; y < h; ++y) {
+        row_pointers[y] = const_cast<png_bytep>(&image[y * w * 4]);
+    }
+
+    png_write_image(png_ptr, row_pointers.data());
+    png_write_end(png_ptr, nullptr);
+
+    png_destroy_write_struct(&png_ptr, &info_ptr);
+    std::fclose(fp);
+    return 0;
+}
+
+} // namespace lodepng
+

--- a/src/cui/lodepng.h
+++ b/src/cui/lodepng.h
@@ -1,0 +1,36 @@
+/*
+LodePNG version 20230410
+
+Copyright (c) 2005-2023 Lode Vandevenne
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgement in the product documentation would be
+    appreciated but is not required.
+    2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+    3. This notice may not be removed or altered from any source
+    distribution.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace lodepng {
+
+unsigned decode(std::vector<unsigned char>& out, unsigned& w, unsigned& h, const std::string& filename);
+unsigned encode(const std::string& filename, const std::vector<unsigned char>& image, unsigned w, unsigned h);
+const char* lodepng_error_text(unsigned code);
+
+} // namespace lodepng
+

--- a/src/cui/msx1pq_cli.cpp
+++ b/src/cui/msx1pq_cli.cpp
@@ -1,0 +1,380 @@
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <iostream>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "../core/MSX1PQCore.h"
+#include "../core/MSX1PQPalettes.h"
+#include "lodepng.h"
+
+namespace fs = std::filesystem;
+
+struct CliOptions {
+    fs::path input_path;
+    fs::path output_dir;
+    bool force{false};
+
+    int color_system{MSX1PQCore::MSX1PQ_COLOR_SYS_MSX1};
+    bool use_dither{true};
+    bool use_dark_dither{true};
+    int use_8dot2col{MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_BASIC1};
+    bool use_hsb{true};
+    float weight_h{1.0f};
+    float weight_s{0.5f};
+    float weight_b{0.75f};
+    float pre_sat{1.0f};
+    float pre_gamma{1.0f};
+    float pre_highlight{1.0f};
+    float pre_hue{0.0f};
+};
+
+struct RgbaPixel {
+    std::uint8_t red;
+    std::uint8_t green;
+    std::uint8_t blue;
+    std::uint8_t alpha;
+};
+static_assert(sizeof(RgbaPixel) == 4, "RgbaPixel must be tightly packed");
+
+namespace {
+
+void print_usage(const char* prog) {
+    std::cout << "Usage: " << prog << " --input <file|dir> --output <dir> [options]\n"
+              << "Options:\n"
+              << "  --color-system <msx1|msx2>   (default: msx1)\n"
+              << "  --dither / --no-dither       (default: dither)\n"
+              << "  --dark-dither / --no-dark-dither (default: use dark dither palettes)\n"
+              << "  --8dot <none|fast|basic|best|best-attr|best-trans> (default: basic)\n"
+              << "  --distance <rgb|hsb>         (default: hsb)\n"
+              << "  --weight-h <0-1> --weight-s <0-1> --weight-b <0-1>\n"
+              << "  --pre-sat <0-10> --pre-gamma <0-10> --pre-highlight <0-10> --pre-hue <-180-180>\n"
+              << "  -f, --force                  Overwrite without confirmation\n";
+}
+
+std::optional<int> parse_8dot_mode(const std::string& value) {
+    static const std::map<std::string, int> kMap = {
+        {"none", MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_NONE},
+        {"fast", MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_FAST1},
+        {"basic", MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_BASIC1},
+        {"best", MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_BEST1},
+        {"best-attr", MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_ATTR_BEST},
+        {"best-trans", MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_PENALTY_BEST},
+    };
+
+    auto it = kMap.find(value);
+    if (it != kMap.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+bool parse_arguments(int argc, char** argv, CliOptions& opts) {
+    if (argc < 2) {
+        print_usage(argv[0]);
+        return false;
+    }
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        auto require_value = [&](const std::string& name) -> std::string {
+            if (i + 1 >= argc) {
+                throw std::runtime_error("Missing value for option: " + name);
+            }
+            return argv[++i];
+        };
+
+        if (arg == "--input" || arg == "-i") {
+            opts.input_path = require_value(arg);
+        } else if (arg == "--output" || arg == "-o") {
+            opts.output_dir = require_value(arg);
+        } else if (arg == "--color-system") {
+            std::string value = require_value(arg);
+            if (value == "msx1") {
+                opts.color_system = MSX1PQCore::MSX1PQ_COLOR_SYS_MSX1;
+            } else if (value == "msx2") {
+                opts.color_system = MSX1PQCore::MSX1PQ_COLOR_SYS_MSX2;
+            } else {
+                throw std::runtime_error("Unknown color system: " + value);
+            }
+        } else if (arg == "--dither") {
+            opts.use_dither = true;
+        } else if (arg == "--no-dither") {
+            opts.use_dither = false;
+        } else if (arg == "--dark-dither") {
+            opts.use_dark_dither = true;
+        } else if (arg == "--no-dark-dither") {
+            opts.use_dark_dither = false;
+        } else if (arg == "--8dot") {
+            auto parsed = parse_8dot_mode(require_value(arg));
+            if (!parsed) {
+                throw std::runtime_error("Unknown 8dot mode");
+            }
+            opts.use_8dot2col = *parsed;
+        } else if (arg == "--distance") {
+            std::string value = require_value(arg);
+            if (value == "rgb") {
+                opts.use_hsb = false;
+            } else if (value == "hsb") {
+                opts.use_hsb = true;
+            } else {
+                throw std::runtime_error("Unknown distance mode: " + value);
+            }
+        } else if (arg == "--weight-h") {
+            opts.weight_h = std::stof(require_value(arg));
+        } else if (arg == "--weight-s") {
+            opts.weight_s = std::stof(require_value(arg));
+        } else if (arg == "--weight-b") {
+            opts.weight_b = std::stof(require_value(arg));
+        } else if (arg == "--pre-sat") {
+            opts.pre_sat = std::stof(require_value(arg));
+        } else if (arg == "--pre-gamma") {
+            opts.pre_gamma = std::stof(require_value(arg));
+        } else if (arg == "--pre-highlight") {
+            opts.pre_highlight = std::stof(require_value(arg));
+        } else if (arg == "--pre-hue") {
+            opts.pre_hue = std::stof(require_value(arg));
+        } else if (arg == "--force" || arg == "-f") {
+            opts.force = true;
+        } else if (arg == "--help" || arg == "-h") {
+            print_usage(argv[0]);
+            return false;
+        } else {
+            throw std::runtime_error("Unknown argument: " + arg);
+        }
+    }
+
+    if (opts.input_path.empty() || opts.output_dir.empty()) {
+        throw std::runtime_error("--input and --output are required");
+    }
+
+    return true;
+}
+
+std::string to_lower_copy(const std::string& s) {
+    std::string result = s;
+    std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return result;
+}
+
+bool has_png_extension(const fs::path& p) {
+    return to_lower_copy(p.extension().string()) == ".png";
+}
+
+bool confirm_overwrite(const fs::path& path) {
+    std::cout << "File " << path << " exists. Overwrite? [y/N]: ";
+    std::string line;
+    std::getline(std::cin, line);
+    if (line.empty()) {
+        return false;
+    }
+    char c = static_cast<char>(std::tolower(line[0]));
+    return c == 'y';
+}
+
+int select_basic_index(const MSX1PQCore::QuantInfo& qi, std::uint8_t r, std::uint8_t g, std::uint8_t b, std::int32_t x, std::int32_t y) {
+    if (qi.use_dither) {
+        int num_colors = MSX1PQ::kNumQuantColors;
+        if (!qi.use_dark_dither) {
+            num_colors = MSX1PQ::kFirstDarkDitherIndex;
+        }
+
+        int palette_idx;
+        if (qi.use_hsb) {
+            palette_idx = MSX1PQCore::nearest_palette_hsb(r, g, b, qi.w_h, qi.w_s, qi.w_b, num_colors);
+        } else {
+            palette_idx = MSX1PQCore::nearest_palette_rgb(r, g, b, num_colors);
+        }
+        return MSX1PQ::palette_index_to_basic_index(palette_idx, x, y);
+    }
+
+    if (qi.use_hsb) {
+        return MSX1PQCore::nearest_basic_hsb(r, g, b, qi.w_h, qi.w_s, qi.w_b);
+    }
+    return MSX1PQ::nearest_basic_rgb(r, g, b);
+}
+
+void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned height, const CliOptions& opts) {
+    MSX1PQCore::QuantInfo qi{};
+    qi.use_dither      = opts.use_dither;
+    qi.use_8dot2col    = opts.use_8dot2col;
+    qi.use_hsb         = opts.use_hsb;
+    qi.w_h             = MSX1PQCore::clamp01f(opts.weight_h);
+    qi.w_s             = MSX1PQCore::clamp01f(opts.weight_s);
+    qi.w_b             = MSX1PQCore::clamp01f(opts.weight_b);
+    qi.pre_sat         = opts.pre_sat;
+    qi.pre_gamma       = opts.pre_gamma;
+    qi.pre_highlight   = opts.pre_highlight;
+    qi.pre_hue         = opts.pre_hue;
+    qi.use_dark_dither = opts.use_dark_dither;
+    qi.color_system    = opts.color_system;
+
+    for (unsigned y = 0; y < height; ++y) {
+        for (unsigned x = 0; x < width; ++x) {
+            RgbaPixel& px = pixels[y * width + x];
+            std::uint8_t r = px.red;
+            std::uint8_t g = px.green;
+            std::uint8_t b = px.blue;
+
+            MSX1PQCore::apply_preprocess(&qi, r, g, b);
+            const int basic_idx = select_basic_index(qi, r, g, b, static_cast<std::int32_t>(x), static_cast<std::int32_t>(y));
+
+            const MSX1PQ::QuantColor& qc = (qi.color_system == MSX1PQCore::MSX1PQ_COLOR_SYS_MSX2)
+                ? MSX1PQ::kBasicColorsMsx2[basic_idx]
+                : MSX1PQ::kQuantColors[basic_idx];
+
+            px.red   = qc.r;
+            px.green = qc.g;
+            px.blue  = qc.b;
+        }
+    }
+
+    if (qi.use_8dot2col != MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_NONE) {
+        const std::ptrdiff_t pitch = static_cast<std::ptrdiff_t>(width);
+        const std::int32_t w = static_cast<std::int32_t>(width);
+        const std::int32_t h = static_cast<std::int32_t>(height);
+
+        switch (qi.use_8dot2col) {
+        case MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_FAST1:
+            MSX1PQCore::apply_8dot2col_fast1(pixels.data(), pitch, w, h, qi.color_system);
+            break;
+        case MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_BASIC1:
+            MSX1PQCore::apply_8dot2col_basic1(pixels.data(), pitch, w, h, qi.color_system);
+            break;
+        case MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_BEST1:
+            MSX1PQCore::apply_8dot2col_best1(pixels.data(), pitch, w, h, qi.color_system);
+            break;
+        case MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_ATTR_BEST:
+            MSX1PQCore::apply_8dot2col_attr_best(pixels.data(), pitch, w, h, qi.color_system);
+            break;
+        case MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_PENALTY_BEST:
+            MSX1PQCore::apply_8dot2col_attr_best_penalty(pixels.data(), pitch, w, h, qi.color_system);
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+bool write_png(const fs::path& output_path, const std::vector<RgbaPixel>& pixels, unsigned width, unsigned height) {
+    std::vector<unsigned char> raw;
+    raw.reserve(pixels.size() * 4);
+    for (const auto& p : pixels) {
+        raw.push_back(p.red);
+        raw.push_back(p.green);
+        raw.push_back(p.blue);
+        raw.push_back(p.alpha);
+    }
+
+    const unsigned error = lodepng::encode(output_path.string(), raw, width, height);
+    if (error) {
+        std::cerr << "Failed to write PNG: " << output_path << " (" << lodepng::lodepng_error_text(error) << ")\n";
+        return false;
+    }
+    return true;
+}
+
+bool process_file(const fs::path& input, const fs::path& output, const CliOptions& opts) {
+    std::vector<unsigned char> raw;
+    unsigned width = 0;
+    unsigned height = 0;
+
+    const unsigned error = lodepng::decode(raw, width, height, input.string());
+    if (error) {
+        std::cerr << "Failed to read PNG: " << input << " (" << lodepng::lodepng_error_text(error) << ")\n";
+        return false;
+    }
+
+    if (raw.size() != static_cast<size_t>(width * height * 4)) {
+        std::cerr << "Unexpected image size for: " << input << "\n";
+        return false;
+    }
+
+    std::vector<RgbaPixel> pixels(width * height);
+    for (unsigned i = 0; i < width * height; ++i) {
+        pixels[i].red   = raw[i * 4 + 0];
+        pixels[i].green = raw[i * 4 + 1];
+        pixels[i].blue  = raw[i * 4 + 2];
+        pixels[i].alpha = raw[i * 4 + 3];
+    }
+
+    quantize_image(pixels, width, height, opts);
+    return write_png(output, pixels, width, height);
+}
+
+std::vector<fs::path> collect_inputs(const fs::path& input_path) {
+    if (fs::is_regular_file(input_path)) {
+        return {input_path};
+    }
+
+    std::vector<fs::path> results;
+    for (const auto& entry : fs::directory_iterator(input_path)) {
+        if (entry.is_regular_file() && has_png_extension(entry.path())) {
+            results.push_back(entry.path());
+        }
+    }
+    std::sort(results.begin(), results.end());
+    return results;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    CliOptions opts;
+    try {
+        if (!parse_arguments(argc, argv, opts)) {
+            return 1;
+        }
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << "\n";
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    if (!fs::exists(opts.input_path)) {
+        std::cerr << "Input path does not exist: " << opts.input_path << "\n";
+        return 1;
+    }
+
+    if (!fs::exists(opts.output_dir)) {
+        fs::create_directories(opts.output_dir);
+    }
+
+    const auto inputs = collect_inputs(opts.input_path);
+    if (inputs.empty()) {
+        std::cerr << "No PNG files to process in: " << opts.input_path << "\n";
+        return 1;
+    }
+
+    int success_count = 0;
+    for (const auto& input : inputs) {
+        fs::path out_path = opts.output_dir / input.filename();
+        if (fs::exists(out_path) && !opts.force) {
+            if (!confirm_overwrite(out_path)) {
+                std::cout << "Skipped: " << out_path << "\n";
+                continue;
+            }
+        }
+
+        if (!has_png_extension(input)) {
+            std::cout << "Skip (not PNG): " << input << "\n";
+            continue;
+        }
+
+        if (process_file(input, out_path, opts)) {
+            std::cout << "Processed: " << input << " -> " << out_path << "\n";
+            ++success_count;
+        }
+    }
+
+    if (success_count == 0) {
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a standalone CLI under src/cui to process PNG files or directories with plugin-compatible parameters
- include a minimal libpng-based PNG helper to read and write RGBA data for the CLI

## Testing
- g++ -std=c++17 -I./src/core -Isrc/cui src/cui/msx1pq_cli.cpp src/cui/lodepng.cpp src/core/MSX1PQCore.cpp src/core/MSX1PQPalettes.cpp -lpng -o msx1pq_cli


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927836102f08324a41d2db0fb1b5ab8)