### PR TITLE
Add CLI output prefix and LUT preprocessing support

### DIFF
--- a/docs/CLI_guide_en.md
+++ b/docs/CLI_guide_en.md
@@ -26,6 +26,7 @@ The compiled binary will be placed at `bin/msx1pq_cli`.
 | --- | --- |
 | `--input, -i <file|dir>` | Input PNG file or directory to process. |
 | `--output, -o <dir>` | Destination directory for converted PNG files. |
+| `--output-prefix <string>` | Prefix added to every output file name. |
 | `--color-system <msx1|msx2>` | Choose MSX1 (15 colors) or MSX2 palette. Default: `msx1`. |
 | `--dither` / `--no-dither` | Enable or disable dithering. Default: enabled. |
 | `--dark-dither` / `--no-dark-dither` | Use dedicated dark-area patterns or skip them. Default: enabled. |
@@ -36,6 +37,7 @@ The compiled binary will be placed at `bin/msx1pq_cli`.
 | `--pre-gamma <0-10>` | Darken midtones before quantizing. Default: `1.0`. |
 | `--pre-highlight <0-10>` | Brighten highlights before quantizing. Default: `1.0`. |
 | `--pre-hue <-180-180>` | Rotate hue before quantizing. Default: `0.0`. |
+| `--pre-lut <.cube file>` | Apply a 3D LUT (CUBE format) before quantizing. |
 | `-f, --force` | Overwrite outputs without confirmation. |
 | `-v, --version` | Show version information. |
 | `-h, --help` | Show help in the detected locale (Japanese if available). |
@@ -59,4 +61,10 @@ Apply stronger saturation and the "best-attr" 8-dot algorithm:
 
 ```bash
 ./bin/msx1pq_cli -i shot.png -o dist --pre-sat 1.4 --8dot best-attr
+```
+
+Add a `msx_` prefix and apply a LUT before quantizing:
+
+```bash
+./bin/msx1pq_cli -i shot.png -o dist --output-prefix msx_ --pre-lut looks/film.cube
 ```

--- a/docs/CLI_guide_ja.md
+++ b/docs/CLI_guide_ja.md
@@ -26,6 +26,7 @@ make
 | --- | --- |
 | `--input, -i <ファイル|ディレクトリ>` | 入力 PNG ファイルまたはディレクトリを指定。 |
 | `--output, -o <ディレクトリ>` | 変換結果を保存するディレクトリを指定。 |
+| `--output-prefix <文字列>` | 出力ファイル名の先頭に付ける文字列。 |
 | `--color-system <msx1|msx2>` | MSX1（15色）か MSX2 パレットを選択。既定: `msx1`。 |
 | `--dither` / `--no-dither` | ディザリングの有無。既定: 有効。 |
 | `--dark-dither` / `--no-dark-dither` | 暗部専用ディザを使うか。既定: 有効。 |
@@ -36,6 +37,7 @@ make
 | `--pre-gamma <0-10>` | 量子化前にガンマを暗くする。既定: `1.0`。 |
 | `--pre-highlight <0-10>` | 量子化前にハイライトを明るくする。既定: `1.0`。 |
 | `--pre-hue <-180-180>` | 量子化前に色相を回転。既定: `0.0`。 |
+| `--pre-lut <.cube ファイル>` | 量子化前に CUBE 形式の 3D LUT を適用。 |
 | `-f, --force` | 確認なしで出力を上書き。 |
 | `-v, --version` | バージョン情報を表示。 |
 | `-h, --help` | ロケールに応じたヘルプを表示（日本語優先）。 |
@@ -59,4 +61,10 @@ make
 
 ```bash
 ./bin/msx1pq_cli -i shot.png -o dist --pre-sat 1.4 --8dot best-attr
+```
+
+`msx_` という接頭語を付け、前処理で LUT を適用:
+
+```bash
+./bin/msx1pq_cli -i shot.png -o dist --output-prefix msx_ --pre-lut looks/film.cube
 ```

--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -20,6 +20,11 @@ struct CliOptions {
     fs::path output_dir;
     bool force{false};
 
+    std::string output_prefix;
+    fs::path pre_lut_path;
+    MSX1PQCore::PreprocessLut pre_lut;
+    bool use_pre_lut{false};
+
     int color_system{MSX1PQCore::MSX1PQ_COLOR_SYS_MSX1};
     bool use_dither{true};
     bool use_dark_dither{true};
@@ -92,6 +97,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
                   << "オプション:\n"
                   << "  --input, -i <ファイル|ディレクトリ>  入力PNGファイルまたはディレクトリを指定\n"
                   << "  --output, -o <ディレクトリ>       出力先ディレクトリを指定\n"
+                  << "  --output-prefix <文字列>        出力ファイル名の先頭に付与する文字列\n"
                   << "  --color-system <msx1|msx2>   (デフォルト: msx1)\n"
                   << "  --dither / --no-dither       (デフォルト: dither)\n"
                   << "  --dark-dither / --no-dark-dither (デフォルト: ダークディザーパレットを使用)\n"
@@ -102,6 +108,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
                   << "  --pre-gamma <0-10>           処理前にガンマを暗く補正 (デフォルト: 1.0)\n"
                   << "  --pre-highlight <0-10>       処理前にハイライトを明るく補正 (デフォルト: 1.0)\n"
                   << "  --pre-hue <-180-180>         処理前に色相を変更 (デフォルト: 0.0)\n"
+                  << "  --pre-lut <.cubeファイル>    処理前に3D LUTを適用 (CUBE形式のみ)\n"
                   << "  -f, --force                  上書き時に確認しない\n"
                   << "  -v, --version                バージョン情報を表示\n"
                   << "  -h, --help                   ロケールに応じてUSAGEを表示\n"
@@ -116,6 +123,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
               << "Options:\n"
               << "  --input, -i <file|dir>       Specify the input PNG file or directory\n"
               << "  --output, -o <dir>           Specify the output directory\n"
+              << "  --output-prefix <string>     Prefix to add to output file names\n"
               << "  --color-system <msx1|msx2>   (default: msx1)\n"
               << "  --dither / --no-dither       (default: dither)\n"
               << "  --dark-dither / --no-dark-dither (default: use dark dither palettes)\n"
@@ -126,6 +134,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
               << "  --pre-gamma <0-10>           Darken gamma before processing (default: 1.0)\n"
               << "  --pre-highlight <0-10>       Brighten highlights before processing (default: 1.0)\n"
               << "  --pre-hue <-180-180>         Adjust hue before processing (default: 0.0)\n"
+              << "  --pre-lut <.cube file>       Apply a 3D LUT before processing (CUBE format only)\n"
               << "  -f, --force                  Overwrite without confirmation\n"
               << "  -v, --version                Show version information\n"
               << "  -h, --help                   Show usage based on locale (Japanese if detected)\n"
@@ -173,6 +182,8 @@ bool parse_arguments(int argc, char** argv, CliOptions& opts) {
             opts.input_path = require_value(arg);
         } else if (arg == "--output" || arg == "-o") {
             opts.output_dir = require_value(arg);
+        } else if (arg == "--output-prefix") {
+            opts.output_prefix = require_value(arg);
         } else if (arg == "--color-system") {
             std::string value = require_value(arg);
             if (value == "msx1") {
@@ -219,6 +230,8 @@ bool parse_arguments(int argc, char** argv, CliOptions& opts) {
             opts.pre_highlight = std::stof(require_value(arg));
         } else if (arg == "--pre-hue") {
             opts.pre_hue = std::stof(require_value(arg));
+        } else if (arg == "--pre-lut") {
+            opts.pre_lut_path = require_value(arg);
         } else if (arg == "--force" || arg == "-f") {
             opts.force = true;
         } else if (arg == "--version" || arg == "-v") {
@@ -304,6 +317,7 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
     qi.pre_hue         = opts.pre_hue;
     qi.use_dark_dither = opts.use_dark_dither;
     qi.color_system    = opts.color_system;
+    qi.pre_lut         = opts.use_pre_lut ? &opts.pre_lut : nullptr;
 
     for (unsigned y = 0; y < height; ++y) {
         for (unsigned x = 0; x < width; ++x) {
@@ -436,6 +450,15 @@ int main(int argc, char** argv) {
         fs::create_directories(opts.output_dir);
     }
 
+    if (!opts.pre_lut_path.empty()) {
+        std::string error_message;
+        if (!MSX1PQCore::load_cube_lut(opts.pre_lut_path.string().c_str(), opts.pre_lut, error_message)) {
+            std::cerr << "Failed to load LUT: " << opts.pre_lut_path << " (" << error_message << ")\n";
+            return 1;
+        }
+        opts.use_pre_lut = true;
+    }
+
     const auto inputs = collect_inputs(opts.input_path);
     if (inputs.empty()) {
         std::cerr << "No PNG files to process in: " << opts.input_path << "\n";
@@ -444,7 +467,12 @@ int main(int argc, char** argv) {
 
     int success_count = 0;
     for (const auto& input : inputs) {
-        fs::path out_path = opts.output_dir / input.filename();
+        fs::path filename = input.filename();
+        if (!opts.output_prefix.empty()) {
+            filename = fs::path(opts.output_prefix + filename.string());
+        }
+
+        fs::path out_path = opts.output_dir / filename;
         if (fs::exists(out_path) && !opts.force) {
             if (!confirm_overwrite(out_path)) {
                 std::cout << "Skipped: " << out_path << "\n";

--- a/src/core/MSX1PQCore.cpp
+++ b/src/core/MSX1PQCore.cpp
@@ -2,6 +2,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cctype>
+#include <fstream>
+#include <sstream>
 
 namespace MSX1PQCore {
 namespace {
@@ -23,6 +26,88 @@ bool  g_palette_hsb_initialized = false;
 float g_palette_h[256];
 float g_palette_s[256];
 float g_palette_b[256];
+
+inline float sample_lut_channel(const PreprocessLut& lut, int r, int g, int b, int channel)
+{
+    int size = lut.size;
+    if (size <= 0) {
+        return 0.0f;
+    }
+
+    if (r < 0) r = 0; else if (r >= size) r = size - 1;
+    if (g < 0) g = 0; else if (g >= size) g = size - 1;
+    if (b < 0) b = 0; else if (b >= size) b = size - 1;
+    if (channel < 0) channel = 0; else if (channel > 2) channel = 2;
+
+    std::size_t idx = static_cast<std::size_t>((r * size * size + g * size + b) * 3 + channel);
+    if (idx >= lut.values.size()) {
+        return 0.0f;
+    }
+    return lut.values[idx];
+}
+
+void apply_lut(const PreprocessLut* lut, std::uint8_t &r8, std::uint8_t &g8, std::uint8_t &b8)
+{
+    if (!lut || lut->size <= 1 || lut->values.empty()) {
+        return;
+    }
+
+    auto normalize = [&](float value, float min_v, float max_v) {
+        if (max_v <= min_v) {
+            return 0.0f;
+        }
+        return clamp01f((value - min_v) / (max_v - min_v));
+    };
+
+    float r = normalize(r8 / 255.0f, lut->domain_min[0], lut->domain_max[0]);
+    float g = normalize(g8 / 255.0f, lut->domain_min[1], lut->domain_max[1]);
+    float b = normalize(b8 / 255.0f, lut->domain_min[2], lut->domain_max[2]);
+
+    const float max_index = static_cast<float>(lut->size - 1);
+    float rf = r * max_index;
+    float gf = g * max_index;
+    float bf = b * max_index;
+
+    int r0 = static_cast<int>(floorf(rf));
+    int g0 = static_cast<int>(floorf(gf));
+    int b0 = static_cast<int>(floorf(bf));
+
+    int r1 = std::min(r0 + 1, lut->size - 1);
+    int g1 = std::min(g0 + 1, lut->size - 1);
+    int b1 = std::min(b0 + 1, lut->size - 1);
+
+    float tr = rf - static_cast<float>(r0);
+    float tg = gf - static_cast<float>(g0);
+    float tb = bf - static_cast<float>(b0);
+
+    auto interp = [&](int channel) {
+        float c000 = sample_lut_channel(*lut, r0, g0, b0, channel);
+        float c100 = sample_lut_channel(*lut, r1, g0, b0, channel);
+        float c010 = sample_lut_channel(*lut, r0, g1, b0, channel);
+        float c110 = sample_lut_channel(*lut, r1, g1, b0, channel);
+        float c001 = sample_lut_channel(*lut, r0, g0, b1, channel);
+        float c101 = sample_lut_channel(*lut, r1, g0, b1, channel);
+        float c011 = sample_lut_channel(*lut, r0, g1, b1, channel);
+        float c111 = sample_lut_channel(*lut, r1, g1, b1, channel);
+
+        float c00 = c000 + (c100 - c000) * tr;
+        float c01 = c001 + (c101 - c001) * tr;
+        float c10 = c010 + (c110 - c010) * tr;
+        float c11 = c011 + (c111 - c011) * tr;
+
+        float c0 = c00 + (c10 - c00) * tg;
+        float c1 = c01 + (c11 - c01) * tg;
+        return c0 + (c1 - c0) * tb;
+    };
+
+    float lr = clamp01f(interp(0));
+    float lg = clamp01f(interp(1));
+    float lb = clamp01f(interp(2));
+
+    r8 = static_cast<std::uint8_t>(lr * 255.0f + 0.5f);
+    g8 = static_cast<std::uint8_t>(lg * 255.0f + 0.5f);
+    b8 = static_cast<std::uint8_t>(lb * 255.0f + 0.5f);
+}
 
 } // namespace
 
@@ -115,9 +200,17 @@ void apply_preprocess(const QuantInfo *qi,
 {
     if (!qi) return;
 
-    if (qi->pre_sat <= 0.0f && qi->pre_gamma <= 0.0f &&
-        qi->pre_highlight <= 0.0f && qi->pre_hue == 0.0f) {
+    const bool has_adjustments = (qi->pre_sat > 0.0f || qi->pre_gamma > 0.0f ||
+                                  qi->pre_highlight > 0.0f || qi->pre_hue != 0.0f);
+    if (!qi->pre_lut && !has_adjustments) {
         return;
+    }
+
+    if (qi->pre_lut) {
+        apply_lut(qi->pre_lut, r8, g8, b8);
+        if (!has_adjustments) {
+            return;
+        }
     }
 
     float h, s, v;
@@ -299,6 +392,88 @@ int transition_cost_pair(int prevA, int prevB, int a, int b)
     if (a == prevB || b == prevA)   return COST_SAME_BUT_SWAP;
 
     return COST_DIFFERENT;
+}
+
+bool load_cube_lut(const char* path, PreprocessLut& out_lut, std::string& error_message)
+{
+    if (!path) {
+        error_message = "Invalid LUT path";
+        return false;
+    }
+
+    std::ifstream ifs(path);
+    if (!ifs) {
+        error_message = "Failed to open LUT file";
+        return false;
+    }
+
+    auto trim = [](std::string& str) {
+        auto is_space = [](unsigned char c) { return std::isspace(c) != 0; };
+        str.erase(str.begin(), std::find_if(str.begin(), str.end(), [&](unsigned char c) { return !is_space(c); }));
+        str.erase(std::find_if(str.rbegin(), str.rend(), [&](unsigned char c) { return !is_space(c); }).base(), str.end());
+    };
+
+    out_lut = PreprocessLut{};
+
+    std::string line;
+    int expected_values = -1;
+    while (std::getline(ifs, line)) {
+        // Remove comments
+        auto comment_pos = line.find('#');
+        if (comment_pos != std::string::npos) {
+            line = line.substr(0, comment_pos);
+        }
+        comment_pos = line.find("//");
+        if (comment_pos != std::string::npos) {
+            line = line.substr(0, comment_pos);
+        }
+
+        trim(line);
+        if (line.empty()) {
+            continue;
+        }
+
+        std::istringstream iss(line);
+        std::string head;
+        iss >> head;
+        if (head == "TITLE") {
+            continue;
+        } else if (head == "LUT_3D_SIZE") {
+            iss >> out_lut.size;
+            if (out_lut.size <= 1) {
+                error_message = "LUT_3D_SIZE must be greater than 1";
+                return false;
+            }
+            expected_values = out_lut.size * out_lut.size * out_lut.size;
+            out_lut.values.reserve(static_cast<std::size_t>(expected_values) * 3);
+        } else if (head == "DOMAIN_MIN") {
+            iss >> out_lut.domain_min[0] >> out_lut.domain_min[1] >> out_lut.domain_min[2];
+        } else if (head == "DOMAIN_MAX") {
+            iss >> out_lut.domain_max[0] >> out_lut.domain_max[1] >> out_lut.domain_max[2];
+        } else {
+            // Assume data line
+            float r, g, b;
+            if (!(std::istringstream(line) >> r >> g >> b)) {
+                error_message = "Failed to parse LUT value line";
+                return false;
+            }
+            out_lut.values.push_back(r);
+            out_lut.values.push_back(g);
+            out_lut.values.push_back(b);
+        }
+    }
+
+    if (out_lut.size <= 1 || expected_values < 0) {
+        error_message = "LUT_3D_SIZE was not specified";
+        return false;
+    }
+
+    if (static_cast<int>(out_lut.values.size() / 3) != expected_values) {
+        error_message = "Unexpected number of LUT entries";
+        return false;
+    }
+
+    return true;
 }
 
 } // namespace MSX1PQCore

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -2,6 +2,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <vector>
 
 #include "MSX1PQPalettes.h"
 
@@ -41,6 +43,14 @@ struct QuantInfo {
     float pre_hue{};
     bool  use_dark_dither{};
     int   color_system{MSX1PQ_COLOR_SYS_MSX1};
+    const struct PreprocessLut* pre_lut{nullptr};
+};
+
+struct PreprocessLut {
+    int size{0};
+    float domain_min[3]{0.0f, 0.0f, 0.0f};
+    float domain_max[3]{1.0f, 1.0f, 1.0f};
+    std::vector<float> values; // RGB triplets, size = size^3 * 3
 };
 
 float clamp01f(float v);
@@ -55,6 +65,8 @@ void apply_preprocess(const QuantInfo *qi,
                       std::uint8_t &r8,
                       std::uint8_t &g8,
                       std::uint8_t &b8);
+
+bool load_cube_lut(const char* path, PreprocessLut& out_lut, std::string& error_message);
 
 int nearest_palette_rgb(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8,
                         int num_colors);


### PR DESCRIPTION
## Summary
- add CLI options for output filename prefixes and preprocessing LUT files
- implement CUBE 3D LUT parsing and apply LUTs during preprocessing
- document the new options in the English and Japanese CLI guides

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927dbfbed908324bad830ed2d7d95d7)