### PR TITLE
Add clamp fallback for preposterize values

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -72,6 +72,7 @@ using MSX1PQCore::nearest_basic_hsb;
 using MSX1PQCore::nearest_palette_hsb;
 using MSX1PQCore::nearest_palette_rgb;
 using MSX1PQCore::clamp01f;
+using MSX1PQCore::clamp_value;
 using MSX1PQCore::MSX1PQ_COLOR_SYS_MSX1;
 using MSX1PQCore::MSX1PQ_COLOR_SYS_MSX2;
 using MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_ATTR_BEST;
@@ -575,7 +576,7 @@ Render (
     qi.w_b = clamp01f(
         static_cast<float>(params[MSX1PQ_PARAM_WEIGHT_B]->u.fs_d.value));
 
-    qi.pre_posterize = std::clamp(
+    qi.pre_posterize = clamp_value(
         static_cast<int>(params[MSX1PQ_PARAM_PRE_POSTERIZE]->u.fs_d.value + 0.5),
         1,
         255);

--- a/src/core/MSX1PQCore.cpp
+++ b/src/core/MSX1PQCore.cpp
@@ -115,7 +115,7 @@ void apply_preprocess(const QuantInfo *qi,
 {
     if (!qi) return;
 
-    const int posterize_levels = std::clamp(qi->pre_posterize, 1, 255);
+    const int posterize_levels = clamp_value(qi->pre_posterize, 1, 255);
     const bool do_posterize = (posterize_levels > 1);
     const bool do_hsv_adjust =
         (qi->pre_sat > 0.0f) || (qi->pre_gamma > 0.0f) ||

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -46,6 +46,12 @@ struct QuantInfo {
 
 float clamp01f(float v);
 
+template <typename T>
+constexpr T clamp_value(const T& v, const T& lo, const T& hi)
+{
+    return (v < lo) ? lo : (v > hi ? hi : v);
+}
+
 void rgb_to_hsb(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8,
                 float &h, float &s, float &v);
 


### PR DESCRIPTION
## Summary
- add a `clamp_value` helper to avoid relying on C++17 `std::clamp`
- use the new helper when clamping pre-posterize values in the After Effects plug-in and core logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692842aba1e48324abc104387964e68a)