### PR TITLE
Update CLI build instructions for msbuild

### DIFF
--- a/docs/CLI_guide_en.md
+++ b/docs/CLI_guide_en.md
@@ -4,11 +4,13 @@ The CLI tool `msx1pq_cli` converts PNG images into MSX1/2-style graphics that fo
 
 ## Build
 
+Build the Visual Studio project with `msbuild`:
+
 ```bash
-make
+msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release /p:Platform=x64
 ```
 
-The compiled binary will be placed at `bin/msx1pq_cli`.
+The compiled binary will be placed at `platform\\Win\\x64\\msx1pq_cli.exe`.
 
 ## Usage
 

--- a/docs/CLI_guide_ja.md
+++ b/docs/CLI_guide_ja.md
@@ -4,11 +4,13 @@ CLI ツール `msx1pq_cli` は、PNG 画像を MSX1/2 風の TMS9918 ルール�
 
 ## ビルド方法
 
+`msbuild` で Visual Studio プロジェクトをビルドします:
+
 ```bash
-make
+msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release /p:Platform=x64
 ```
 
-ビルド後、実行ファイルは `bin/msx1pq_cli` に生成されます。
+ビルド後、実行ファイルは `platform\\Win\\x64\\msx1pq_cli.exe` に生成されます。
 
 ## 使い方
 


### PR DESCRIPTION
## Summary
- update CLI English and Japanese guides to show msbuild command for the Visual Studio project
- correct the documented output path for the built CLI binary

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928433d2d0c83249d9d43c5c70e09b2)