### PR TITLE
Fix packaging script LASTEXITCODE handling

### DIFF
--- a/tools/package_dist.bat
+++ b/tools/package_dist.bat
@@ -55,7 +55,7 @@ set "ZIP_PATH=%DIST_DIR%\%ZIP_NAME%"
 if exist "%ZIP_PATH%" del /f /q "%ZIP_PATH%"
 
 echo Creating ZIP archive: %ZIP_PATH%
-powershell -NoProfile -Command "Set-StrictMode -Version Latest; Set-Location '%DIST_DIR%'; $items = Get-ChildItem -Force | Where-Object { $_.Extension -ne '.zip' }; if (-not $items) { Write-Error 'No files to archive.'; exit 1 }; Compress-Archive -Path $items -DestinationPath '%ZIP_PATH%' -Force; exit $LASTEXITCODE"
+powershell -NoProfile -Command "Set-StrictMode -Version Latest; Set-Location '%DIST_DIR%'; $global:LASTEXITCODE = 0; $items = Get-ChildItem -Force | Where-Object { $_.Extension -ne '.zip' }; if (-not $items) { Write-Error 'No files to archive.'; exit 1 }; Compress-Archive -Path $items -DestinationPath '%ZIP_PATH%' -Force; $exitCode = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } elseif ($?) { 0 } else { 1 }; exit $exitCode"
 if errorlevel 1 (
     echo Failed to create ZIP archive.
     exit /b 1


### PR DESCRIPTION
## Summary
- initialize the PowerShell environment in package_dist.bat so LASTEXITCODE is defined under strict mode
- capture a safe exit code after Compress-Archive to avoid failures when packaging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928cc81331c832483f5e12e641c0497)