### PR TITLE
Add LUT preprocessing option to CLI

### DIFF
--- a/src/core/MSX1PQCore.cpp
+++ b/src/core/MSX1PQCore.cpp
@@ -115,6 +115,15 @@ void apply_preprocess(const QuantInfo *qi,
 {
     if (!qi) return;
 
+    if (qi->pre_lut) {
+        auto apply_lut = [lut = qi->pre_lut](std::uint8_t v, int offset) {
+            return lut[static_cast<std::size_t>(v) * 3 + offset];
+        };
+        r8 = apply_lut(r8, 0);
+        g8 = apply_lut(g8, 1);
+        b8 = apply_lut(b8, 2);
+    }
+
     const int posterize_levels = clamp_value(qi->pre_posterize, 0, 255);
     const bool do_posterize = (posterize_levels > 1);
     const bool do_hsv_adjust =

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -42,6 +42,7 @@ struct QuantInfo {
     float pre_hue{};
     bool  use_dark_dither{};
     int   color_system{MSX1PQ_COLOR_SYS_MSX1};
+    const std::uint8_t* pre_lut{nullptr};
 };
 
 float clamp01f(float v);


### PR DESCRIPTION
## Summary
- add --pre-lut option to the CLI with usage help
- parse LUT files containing 256 RGB triplets and feed data into processing
- apply optional LUT in core preprocessing before existing adjustments

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928dd03d3788324b2a423eb67611f7f)