### PR TITLE
Move LUT parsing into core module

### DIFF
--- a/src/core/MSX1PQCore.cpp
+++ b/src/core/MSX1PQCore.cpp
@@ -1,7 +1,14 @@
 #include "MSX1PQCore.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace MSX1PQCore {
 namespace {
@@ -18,6 +25,87 @@ inline float min3f(float a, float b, float c)
     return (m < c) ? m : c;
 }
 
+std::string to_lower_copy(const std::string& s)
+{
+    std::string result = s;
+    std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return result;
+}
+
+bool parse_cube_lut(std::istream& file, std::vector<float>& out3d, int& lut_size)
+{
+    lut_size = 0;
+    out3d.clear();
+
+    std::vector<std::array<float, 3>> rows;
+    std::string line;
+
+    auto normalize_value = [](float v, float max_value) {
+        if (max_value <= 1.0f) {
+            return clamp_value(v, 0.0f, 1.0f);
+        }
+        return clamp_value(v / max_value, 0.0f, 1.0f);
+    };
+
+    while (std::getline(file, line)) {
+        const auto hash_pos = line.find('#');
+        if (hash_pos != std::string::npos) {
+            line = line.substr(0, hash_pos);
+        }
+
+        std::istringstream iss(line);
+        std::string token;
+        if (!(iss >> token)) {
+            continue;
+        }
+
+        if (token == "LUT_3D_SIZE") {
+            iss >> lut_size;
+            continue;
+        }
+
+        float r, g, b;
+        try {
+            r = std::stof(token);
+        } catch (...) {
+            continue;
+        }
+        if (!(iss >> g >> b)) {
+            continue;
+        }
+        rows.push_back({r, g, b});
+    }
+
+    if (rows.empty()) {
+        return false;
+    }
+
+    if (lut_size == 0) {
+        lut_size = static_cast<int>(std::round(std::cbrt(static_cast<double>(rows.size()))));
+    }
+
+    const std::size_t expected_entries = static_cast<std::size_t>(lut_size) * lut_size * lut_size;
+    if (expected_entries != rows.size()) {
+        return false;
+    }
+
+    float max_value = 1.0f;
+    for (const auto& row : rows) {
+        max_value = std::max({max_value, row[0], row[1], row[2]});
+    }
+
+    out3d.reserve(rows.size() * 3);
+    for (const auto& row : rows) {
+        out3d.push_back(normalize_value(row[0], max_value));
+        out3d.push_back(normalize_value(row[1], max_value));
+        out3d.push_back(normalize_value(row[2], max_value));
+    }
+
+    return true;
+}
+
 // パレットのHSBを一度だけ計算してキャッシュ
 bool  g_palette_hsb_initialized = false;
 float g_palette_h[256];
@@ -31,6 +119,70 @@ float clamp01f(float v)
     if (v < 0.0f) return 0.0f;
     if (v > 1.0f) return 1.0f;
     return v;
+}
+
+bool load_pre_lut(const std::filesystem::path& path,
+                  std::vector<std::uint8_t>& out1d,
+                  std::vector<float>& out3d,
+                  int& lut3d_size)
+{
+    out1d.clear();
+    out3d.clear();
+    lut3d_size = 0;
+
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        std::cerr << "Failed to open LUT file: " << path << "\n";
+        return false;
+    }
+
+    const std::string ext = to_lower_copy(path.extension().string());
+    if (ext == ".cube") {
+        if (parse_cube_lut(file, out3d, lut3d_size)) {
+            return true;
+        }
+
+        file.clear();
+        file.seekg(0);
+    }
+
+    std::vector<int> values;
+    values.reserve(256 * 3);
+
+    std::string line;
+    while (std::getline(file, line)) {
+        const auto comment_pos = line.find('#');
+        if (comment_pos != std::string::npos) {
+            line = line.substr(0, comment_pos);
+        }
+        for (char& c : line) {
+            if (c == ',' || c == ';') {
+                c = ' ';
+            }
+        }
+
+        std::istringstream iss(line);
+        int v;
+        while (iss >> v) {
+            if (v < 0 || v > 255) {
+                std::cerr << "LUT value out of range (0-255): " << v << "\n";
+                return false;
+            }
+            values.push_back(v);
+        }
+    }
+
+    if (values.size() != 256 * 3) {
+        std::cerr << "LUT must contain 256 RGB triplets (found " << values.size() << " values)\n";
+        return false;
+    }
+
+    out1d.resize(values.size());
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        out1d[i] = static_cast<std::uint8_t>(values[i]);
+    }
+
+    return true;
 }
 
 void rgb_to_hsb(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8,
@@ -115,7 +267,95 @@ void apply_preprocess(const QuantInfo *qi,
 {
     if (!qi) return;
 
-    if (qi->pre_lut) {
+    if (qi->pre_lut3d && qi->pre_lut3d_size > 1) {
+        const int lut_size = qi->pre_lut3d_size;
+        const float scale  = static_cast<float>(lut_size - 1);
+
+        struct LutSample {
+            int idx0;
+            int idx1;
+            float t;
+        };
+
+        auto sample = [&](float v) -> LutSample {
+            float pos  = v * scale;
+            int idx0   = static_cast<int>(floorf(pos));
+            int idx1   = idx0 + 1;
+            float t    = pos - static_cast<float>(idx0);
+            if (idx1 >= lut_size) {
+                idx1 = lut_size - 1;
+            }
+            return {idx0, idx1, t};
+        };
+
+        auto lerp = [](float a, float b, float t) {
+            return a + (b - a) * t;
+        };
+
+        const auto rx = sample(static_cast<float>(r8) / 255.0f);
+        const auto ry = sample(static_cast<float>(g8) / 255.0f);
+        const auto rz = sample(static_cast<float>(b8) / 255.0f);
+
+        auto lut_index = [lut_size](int x, int y, int z) {
+            return ((z * lut_size + y) * lut_size + x) * 3;
+        };
+
+        auto fetch = [&](int x, int y, int z, int offset) {
+            return qi->pre_lut3d[lut_index(x, y, z) + offset];
+        };
+
+        float c000_r = fetch(rx.idx0, ry.idx0, rz.idx0, 0);
+        float c000_g = fetch(rx.idx0, ry.idx0, rz.idx0, 1);
+        float c000_b = fetch(rx.idx0, ry.idx0, rz.idx0, 2);
+
+        float c100_r = fetch(rx.idx1, ry.idx0, rz.idx0, 0);
+        float c100_g = fetch(rx.idx1, ry.idx0, rz.idx0, 1);
+        float c100_b = fetch(rx.idx1, ry.idx0, rz.idx0, 2);
+
+        float c010_r = fetch(rx.idx0, ry.idx1, rz.idx0, 0);
+        float c010_g = fetch(rx.idx0, ry.idx1, rz.idx0, 1);
+        float c010_b = fetch(rx.idx0, ry.idx1, rz.idx0, 2);
+
+        float c110_r = fetch(rx.idx1, ry.idx1, rz.idx0, 0);
+        float c110_g = fetch(rx.idx1, ry.idx1, rz.idx0, 1);
+        float c110_b = fetch(rx.idx1, ry.idx1, rz.idx0, 2);
+
+        float c001_r = fetch(rx.idx0, ry.idx0, rz.idx1, 0);
+        float c001_g = fetch(rx.idx0, ry.idx0, rz.idx1, 1);
+        float c001_b = fetch(rx.idx0, ry.idx0, rz.idx1, 2);
+
+        float c101_r = fetch(rx.idx1, ry.idx0, rz.idx1, 0);
+        float c101_g = fetch(rx.idx1, ry.idx0, rz.idx1, 1);
+        float c101_b = fetch(rx.idx1, ry.idx0, rz.idx1, 2);
+
+        float c011_r = fetch(rx.idx0, ry.idx1, rz.idx1, 0);
+        float c011_g = fetch(rx.idx0, ry.idx1, rz.idx1, 1);
+        float c011_b = fetch(rx.idx0, ry.idx1, rz.idx1, 2);
+
+        float c111_r = fetch(rx.idx1, ry.idx1, rz.idx1, 0);
+        float c111_g = fetch(rx.idx1, ry.idx1, rz.idx1, 1);
+        float c111_b = fetch(rx.idx1, ry.idx1, rz.idx1, 2);
+
+        auto interp_channel = [&](float c000, float c100, float c010, float c110,
+                                  float c001, float c101, float c011, float c111) {
+            float c00 = lerp(c000, c100, rx.t);
+            float c01 = lerp(c001, c101, rx.t);
+            float c10 = lerp(c010, c110, rx.t);
+            float c11 = lerp(c011, c111, rx.t);
+
+            float c0 = lerp(c00, c10, ry.t);
+            float c1 = lerp(c01, c11, ry.t);
+            return lerp(c0, c1, rz.t);
+        };
+
+        float rf = interp_channel(c000_r, c100_r, c010_r, c110_r, c001_r, c101_r, c011_r, c111_r);
+        float gf = interp_channel(c000_g, c100_g, c010_g, c110_g, c001_g, c101_g, c011_g, c111_g);
+        float bf = interp_channel(c000_b, c100_b, c010_b, c110_b, c001_b, c101_b, c011_b, c111_b);
+
+        r8 = static_cast<std::uint8_t>(clamp_value(rf * 255.0f + 0.5f, 0.0f, 255.0f));
+        g8 = static_cast<std::uint8_t>(clamp_value(gf * 255.0f + 0.5f, 0.0f, 255.0f));
+        b8 = static_cast<std::uint8_t>(clamp_value(bf * 255.0f + 0.5f, 0.0f, 255.0f));
+    } else if (qi->pre_lut) {
         auto apply_lut = [lut = qi->pre_lut](std::uint8_t v, int offset) {
             return lut[static_cast<std::size_t>(v) * 3 + offset];
         };

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -2,6 +2,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <vector>
 
 #include "MSX1PQPalettes.h"
 
@@ -43,7 +45,14 @@ struct QuantInfo {
     bool  use_dark_dither{};
     int   color_system{MSX1PQ_COLOR_SYS_MSX1};
     const std::uint8_t* pre_lut{nullptr};
+    const float* pre_lut3d{nullptr};
+    int pre_lut3d_size{0};
 };
+
+bool load_pre_lut(const std::filesystem::path& path,
+                  std::vector<std::uint8_t>& out1d,
+                  std::vector<float>& out3d,
+                  int& lut3d_size);
 
 float clamp01f(float v);
 


### PR DESCRIPTION
## Summary
- move LUT loading and parsing into the core module so LUT handling is reusable beyond the CLI
- update the CLI to use the shared core loader while keeping existing preprocessing options intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929093f7da48324b0bbaa93f8e196c3)