### PR TITLE
Add missing options to CLI guides

### DIFF
--- a/docs/CLI_guide_en.md
+++ b/docs/CLI_guide_en.md
@@ -28,16 +28,19 @@ The compiled binary will be placed at `platform\\Win\\x64\\msx1pq_cli.exe`.
 | --- | --- |
 | `--input, -i <file|dir>` | Input PNG file or directory to process. |
 | `--output, -o <dir>` | Destination directory for converted PNG files. |
+| `--output-prefix <string>` | Prefix added to every output file name. |
 | `--color-system <msx1|msx2>` | Choose MSX1 (15 colors) or MSX2 palette. Default: `msx1`. |
 | `--dither` / `--no-dither` | Enable or disable dithering. Default: enabled. |
 | `--dark-dither` / `--no-dark-dither` | Use dedicated dark-area patterns or skip them. Default: enabled. |
 | `--8dot <none|fast|basic|best|best-attr|best-trans>` | Pick the 8-dot/2-color algorithm. Default: `best`. |
 | `--distance <rgb|hsb>` | Color distance mode for palette selection. Default: `hsb`. |
 | `--weight-h`, `--weight-s`, `--weight-b` | Weights (0–1) for hue, saturation, and brightness when `hsb` distance is selected. |
+| `--pre-posterize <0-255>` | Posterize before processing (default: `16`; skipped if `<=1`). |
 | `--pre-sat <0-10>` | Boost saturation before quantizing. Default: `1.0`. |
 | `--pre-gamma <0-10>` | Darken midtones before quantizing. Default: `1.0`. |
 | `--pre-highlight <0-10>` | Brighten highlights before quantizing. Default: `1.0`. |
 | `--pre-hue <-180-180>` | Rotate hue before quantizing. Default: `0.0`. |
+| `--pre-lut <file>` | Apply an RGB LUT (256-row table) or a `.cube` 3D LUT before processing. |
 | `-f, --force` | Overwrite outputs without confirmation. |
 | `-v, --version` | Show version information. |
 | `-h, --help` | Show help in the detected locale (Japanese if available). |

--- a/docs/CLI_guide_ja.md
+++ b/docs/CLI_guide_ja.md
@@ -28,16 +28,19 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 | --- | --- |
 | `--input, -i <ファイル|ディレクトリ>` | 入力 PNG ファイルまたはディレクトリを指定。 |
 | `--output, -o <ディレクトリ>` | 変換結果を保存するディレクトリを指定。 |
+| `--output-prefix <文字列>` | 出力ファイル名の先頭に付与する接頭辞。 |
 | `--color-system <msx1|msx2>` | MSX1（15色）か MSX2 パレットを選択。既定: `msx1`。 |
 | `--dither` / `--no-dither` | ディザリングの有無。既定: 有効。 |
 | `--dark-dither` / `--no-dark-dither` | 暗部専用ディザを使うか。既定: 有効。 |
 | `--8dot <none|fast|basic|best|best-attr|best-trans>` | 8ドット2色アルゴリズムを選択。既定: `best`。 |
 | `--distance <rgb|hsb>` | パレット選択時の色距離計算方法。既定: `hsb`。 |
 | `--weight-h`, `--weight-s`, `--weight-b` | `hsb` 距離使用時の色相・彩度・明度の重み（0〜1）。 |
+| `--pre-posterize <0-255>` | 前処理でポスタリゼーションを適用（既定: `16`。`<=1` で無効）。 |
 | `--pre-sat <0-10>` | 量子化前に彩度を上げる。既定: `1.0`。 |
 | `--pre-gamma <0-10>` | 量子化前にガンマを暗くする。既定: `1.0`。 |
 | `--pre-highlight <0-10>` | 量子化前にハイライトを明るくする。既定: `1.0`。 |
 | `--pre-hue <-180-180>` | 量子化前に色相を回転。既定: `0.0`。 |
+| `--pre-lut <ファイル>` | 256行の RGB LUT または `.cube` 形式の 3D LUT を前処理として適用。 |
 | `-f, --force` | 確認なしで出力を上書き。 |
 | `-v, --version` | バージョン情報を表示。 |
 | `-h, --help` | ロケールに応じたヘルプを表示（日本語優先）。 |


### PR DESCRIPTION
## Summary
- document output prefix, posterize, and LUT preprocessing options in the CLI guides
- update both English and Japanese tables to mirror the CLI help text

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69292f1571808324b674ec225fbbbd21)