### PR TITLE
Move palette-only checkbox to end of UI

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.h
+++ b/src/ae/MSX1PaletteQuantizer.h
@@ -38,6 +38,8 @@ enum MSX1PQ_ParamId {
     MSX1PQ_PARAM_PRE_HIGHLIGHT,   // Highlight correction
     MSX1PQ_PARAM_PRE_HUE,         // Hue rotation
 
+    MSX1PQ_PARAM_USE_PALETTE_COLOR, // Use 92-color palette directly
+
     MSX1PQ_PARAM_NUM_PARAMS
 };
 

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -32,6 +32,7 @@ enum MSX1PQ_ColorSystem {
 
 struct QuantInfo {
     bool  use_dither{};
+    bool  use_palette_color{};
     int   use_8dot2col{};
     bool  use_hsb{};
     float w_h{};


### PR DESCRIPTION
## Summary
- reorder the palette-only parameter to appear last in the AE/Premiere UI
- update the parameter enum to match the new UI order

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69295cce129c832491c0a459e55fff16)