### PR TITLE
Consolidate 92-color palette mode into core quantization

### DIFF
--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -89,6 +89,13 @@ const MSX1PQ::QuantColor* get_basic_palette(int color_system);
 int find_basic_index_from_rgb(std::uint8_t r, std::uint8_t g, std::uint8_t b,
                               int color_system);
 
+MSX1PQ::QuantColor quantize_pixel(const QuantInfo& qi,
+                                  std::uint8_t r,
+                                  std::uint8_t g,
+                                  std::uint8_t b,
+                                  std::int32_t x,
+                                  std::int32_t y);
+
 // ------------------------------------------------------------
 // 横8ドット内2色制限
 // ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a shared core quantize_pixel helper covering palette-only and dithered paths
- update the CLI and AE/Premiere plugins to call the shared helper for consistent 92-color handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a17c918f08324a4f51f04654bc37f)