### PR TITLE
Add ROI optimization dropdown to AE/Premiere UI

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -162,7 +162,20 @@ ParamsSetup (
     PF_Err err = PF_Err_NONE;
     PF_ParamDef def;
 
+    AEFX_CLR_STRUCT(def);
     // 入力レイヤーは暗黙に 0 番として存在するので何もしない
+    // Premiere ではデフォルト固定のため変更不可
+    if (in_data->appl_id == kAppID_Premiere) {
+        def.ui_flags |= PF_PUI_DISABLED;
+        def.flags    |= PF_ParamFlag_CANNOT_TIME_VARY;
+    }
+    PF_ADD_POPUP(
+        "ROI optimization",
+        3,                    // 項目数
+        MSX1PQ_ROI_OPTIMIZATION_AUTO, // デフォルト 3: Auto
+        "Disabled|Enabled|Auto",
+        MSX1PQ_PARAM_ROI_OPTIMIZATION);
+
     AEFX_CLR_STRUCT(def);
     PF_ADD_POPUP(
         "Color system",

--- a/src/ae/MSX1PaletteQuantizer.h
+++ b/src/ae/MSX1PaletteQuantizer.h
@@ -19,10 +19,17 @@
 
 #include "../core/MSX1PQCore.h"
 
+enum MSX1PQ_RoiOptimization {
+    MSX1PQ_ROI_OPTIMIZATION_OFF = 1,
+    MSX1PQ_ROI_OPTIMIZATION_ON,
+    MSX1PQ_ROI_OPTIMIZATION_AUTO,
+};
+
 // ParamsSetup() の追加順と必ず一致させること
 enum MSX1PQ_ParamId {
     MSX1PQ_PARAM_INPUT = 0,       // Input layer
 
+    MSX1PQ_PARAM_ROI_OPTIMIZATION, // ROI optimization
     MSX1PQ_PARAM_COLOR_SYSTEM,    // MSX1 / MSX2
     MSX1PQ_PARAM_USE_DITHER,      // Dither ON/OFF
     MSX1PQ_PARAM_USE_DARK_DITHER, // Whether to use a dark dither palette


### PR DESCRIPTION
## Summary
- add a new ROI optimization dropdown at the top of the effect UI
- set options to Disabled/Enabled/Auto with Auto as the default selection
- disable the ROI optimization control in Premiere so the default value remains fixed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a5f9fb4648324b1f3ea9bbcfdad9a)