### PR TITLE
Remove unused ROI optimization UI

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -204,14 +204,6 @@ ParamsSetup (
     }
     def.flags    |= PF_ParamFlag_CANNOT_TIME_VARY;
     PF_ADD_POPUP(
-        "ROI optimization",
-        3,                    // 項目数
-        MSX1PQ_ROI_OPTIMIZATION_AUTO, // デフォルト 3: Auto
-        "Disabled|Enabled|Auto",
-        MSX1PQ_PARAM_ROI_OPTIMIZATION);
-
-    AEFX_CLR_STRUCT(def);
-    PF_ADD_POPUP(
         "Color system",
         2,                    // 項目数
         MSX1PQ_COLOR_SYS_MSX1,       // デフォルト 1: MSX1

--- a/src/ae/MSX1PaletteQuantizer.h
+++ b/src/ae/MSX1PaletteQuantizer.h
@@ -19,17 +19,10 @@
 
 #include "../core/MSX1PQCore.h"
 
-enum MSX1PQ_RoiOptimization {
-    MSX1PQ_ROI_OPTIMIZATION_OFF = 1,
-    MSX1PQ_ROI_OPTIMIZATION_ON,
-    MSX1PQ_ROI_OPTIMIZATION_AUTO,
-};
-
 // ParamsSetup() の追加順と必ず一致させること
 enum MSX1PQ_ParamId {
     MSX1PQ_PARAM_INPUT = 0,       // Input layer
 
-    MSX1PQ_PARAM_ROI_OPTIMIZATION, // ROI optimization
     MSX1PQ_PARAM_COLOR_SYSTEM,    // MSX1 / MSX2
     MSX1PQ_PARAM_USE_DITHER,      // Dither ON/OFF
     MSX1PQ_PARAM_USE_DARK_DITHER, // Whether to use a dark dither palette


### PR DESCRIPTION
## Summary
- remove the unused ROI optimization parameter enum and UI setup from the After Effects/Premiere plugin

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bcf69b8548324869654c422ddd758)