### PR TITLE
Enable multi-frame rendering

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -155,10 +155,12 @@ GlobalSetup (
 
         out_data->out_flags  = PF_OutFlag_NONE;
         out_data->out_flags2 = PF_OutFlag2_SUPPORTS_SMART_RENDER |
-                               PF_OutFlag2_SUPPORTS_MF_RENDER;
-    //	MyDebugLog("GlobalSetup: out_flags=0x%08X, out_flags2=0x%08X",
-    //                    (unsigned int)out_data->out_flags,
-    //                    (unsigned int)out_data->out_flags2); この値を rファイルに書く
+                               PF_OutFlag2_SUPPORTS_THREADED_RENDERING;
+    //PF_OutFlag2_SUPPORTS_SMART_RENDER = 0x0400
+    //PF_OutFlag2_SUPPORTS_THREADED_RENDERING = 0x08000000?
+    MyDebugLog("GlobalSetup: out_flags=0x%08X, out_flags2=0x%08X",
+                    (unsigned int)out_data->out_flags,
+                    (unsigned int)out_data->out_flags2); //この値を rファイルに書く 0x08000400
 
     // Premiere 用ピクセルフォーマット宣言
     if (in_dataP->appl_id == kAppID_Premiere){

--- a/src/ae/MSX1PaletteQuantizerPiPL.r
+++ b/src/ae/MSX1PaletteQuantizerPiPL.r
@@ -48,11 +48,13 @@ resource 'PiPL' (16000) {
 		AE_Effect_Global_OutFlags {
 			PF_OutFlag_NONE
 		},
-                AE_Effect_Global_OutFlags_2 {
-                        PF_OutFlag2_SUPPORTS_SMART_RENDER |
-                        PF_OutFlag2_SUPPORTS_MF_RENDER
-                        /* PF_OutFlag2_SUPPORTS_SMART_RENDER: 0x00000400 */
-                },
+        AE_Effect_Global_OutFlags_2 {
+            0x08000400
+            /*
+                PF_OutFlag2_SUPPORTS_SMART_RENDER: 0x00000400
+                PF_OutFlag2_SUPPORTS_THREADED_RENDERING: 0x08000000?
+            */
+        },
 		AE_Effect_Match_Name {
 			"MMSXX_MSX1PaletteQuantizer"
 		},


### PR DESCRIPTION
## Summary
- enable the After Effects plug-in to advertise multi-frame rendering support
- update the PiPL resource to declare the new out flag alongside smart render

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c29707da8832490228aead27cadd8)