### PR TITLE
Add SC5 output option to CLI

### DIFF
--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -460,6 +460,23 @@ bool write_sc5(const fs::path& output_path, const std::vector<RgbaPixel>& pixels
         std::cerr << "Failed to open output file: " << output_path << "\n";
         return false;
     }
+
+    // SC5ヘッダ
+    unsigned char header[7];
+    header[0] = 0xFE;      // BSAVE signature
+    header[1] = 0x00;      // Start low
+    header[2] = 0x00;      // Start high
+    header[3] = 0x00;      // End low   (0x6B00)
+    header[4] = 0x6B;      // End high
+    header[5] = 0x00;      // Exec low
+    header[6] = 0x00;      // Exec high
+
+    ofs.write(reinterpret_cast<const char*>(header), 7);
+    if (!ofs) {
+        std::cerr << "Failed to write BSAVE header: " << output_path << "\n";
+        return false;
+    }
+
     ofs.write(reinterpret_cast<const char*>(packed.data()), static_cast<std::streamsize>(packed.size()));
     if (!ofs) {
         std::cerr << "Failed to write SC5 data: " << output_path << "\n";


### PR DESCRIPTION
## Summary
- add a new `--out-sc5` flag to emit SCREEN5 `.sc5` files instead of PNGs
- map quantized pixels to 16-color palettes per selected color system and pack SCREEN5 VRAM layout
- center crop/pad images to 256×212 and adjust CLI usage/output handling for SC5 exports

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d01ad579c8324b0e394f119dfdc8a)