### PR TITLE
Add Nuitka EXE build for basic_sc2_viewer

### DIFF
--- a/pyutils/basic_sc2_viewer/README.md
+++ b/pyutils/basic_sc2_viewer/README.md
@@ -14,3 +14,21 @@ usage:
 ```
 python basic_sc2_viewer.py -i images image001.sc2 -o image.dsk
 ```
+
+## Build an EXE with Nuitka
+
+You can bundle the script into a standalone executable (useful for Windows) with Nuitka.
+
+1. Install the Python dependencies from the repository root (Python 3.11+).
+
+   ```
+   pip install -r requirements.txt
+   ```
+
+2. Run the helper script to invoke Nuitka.
+
+   ```
+   python pyutils/basic_sc2_viewer/make_exe.py
+   ```
+
+   The resulting executable is written to `pyutils/basic_sc2_viewer/dist/basic_sc2_viewer.exe` by default. Use `--output-dir` to change the destination.

--- a/pyutils/basic_sc2_viewer/make_exe.py
+++ b/pyutils/basic_sc2_viewer/make_exe.py
@@ -1,0 +1,54 @@
+"""Utilities to bundle basic_sc2_viewer into a single-file executable with Nuitka."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def build_executable(output_dir: Path) -> None:
+    """Compile ``basic_sc2_viewer.py`` into a one-file executable via Nuitka."""
+    script_dir = Path(__file__).resolve().parent
+    target = script_dir / "src" / "basic_sc2_viewer.py"
+    if not target.exists():
+        raise FileNotFoundError(f"Cannot find source script: {target}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "nuitka",
+        "--onefile",
+        "--remove-output",
+        "--assume-yes-for-downloads",
+        f"--output-dir={output_dir}",
+        "--include-package=msxdisk",
+        str(target),
+    ]
+
+    print("Running Nuitka:")
+    print(" ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build a standalone executable for basic_sc2_viewer using Nuitka",
+    )
+    default_output = Path(__file__).resolve().parent / "dist"
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=default_output,
+        help=f"Directory for the generated executable (default: {default_output})",
+    )
+    args = parser.parse_args()
+
+    build_executable(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper script to compile basic_sc2_viewer into a one-file executable with Nuitka
- document the Nuitka build steps and default output location

## Testing
- python pyutils/basic_sc2_viewer/make_exe.py --help


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d984c5db48324aecbba39ba003c40)