### PR TITLE
Align SC5 image placement with SC2 behavior

### DIFF
--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -445,10 +445,10 @@ bool write_sc5(const fs::path& output_path, const std::vector<RgbaPixel>& pixels
     const int copy_width = static_cast<int>(std::min<unsigned>(kSc5Width, width));
     const int copy_height = static_cast<int>(std::min<unsigned>(kSc5Height, height));
 
-    const int src_offset_x = (width > kSc5Width) ? static_cast<int>((width - kSc5Width) / 2) : 0;
-    const int src_offset_y = (height > kSc5Height) ? static_cast<int>((height - kSc5Height) / 2) : 0;
-    const int dst_offset_x = (width < kSc5Width) ? static_cast<int>((kSc5Width - width) / 2) : 0;
-    const int dst_offset_y = (height < kSc5Height) ? static_cast<int>((kSc5Height - height) / 2) : 0;
+    const int src_offset_x = 0;
+    const int src_offset_y = 0;
+    const int dst_offset_x = 0;
+    const int dst_offset_y = 0;
 
     for (int y = 0; y < copy_height; ++y) {
         const unsigned src_y = static_cast<unsigned>(src_offset_y + y);


### PR DESCRIPTION
## Summary
- align SC5 export positioning with SC2 by copying from the top-left
- rely on default color 0 padding when images are smaller than the SC5 canvas

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dad4a67888324948d0693b44b832e)