### PR TITLE
Add CLI option to skip preprocessing

### DIFF
--- a/docs/CLI_guide_en.md
+++ b/docs/CLI_guide_en.md
@@ -32,6 +32,7 @@ The compiled binary will be placed at `platform\\Win\\x64\\msx1pq_cli.exe`.
 | `--color-system <msx1|msx2>` | Choose MSX1 (15 colors) or MSX2 palette. Default: `msx1`. |
 | `--dither` / `--no-dither` | Enable or disable dithering. Default: enabled. |
 | `--dark-dither` / `--no-dark-dither` | Use dedicated dark-area patterns or skip them. Default: enabled. |
+| `--no-preprocess` | Skip all preprocessing tweaks (posterize, saturation, gamma, highlight, hue, LUT). |
 | `--8dot <none|fast|basic|best|best-attr|best-trans>` | Pick the 8-dot/2-color algorithm. Default: `best`. |
 | `--distance <rgb|hsb>` | Color distance mode for palette selection. Default: `hsb`. |
 | `--weight-h`, `--weight-s`, `--weight-b` | Weights (0–1) for hue, saturation, and brightness when `hsb` distance is selected. |

--- a/docs/CLI_guide_ja.md
+++ b/docs/CLI_guide_ja.md
@@ -32,6 +32,7 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 | `--color-system <msx1|msx2>` | MSX1（15色）か MSX2 パレットを選択。既定: `msx1`。 |
 | `--dither` / `--no-dither` | ディザリングの有無。既定: 有効。 |
 | `--dark-dither` / `--no-dark-dither` | 暗部専用ディザを使うか。既定: 有効。 |
+| `--no-preprocess` | すべての前処理（ポスタリゼーション、彩度、ガンマ、ハイライト、色相、LUT）をスキップ。 |
 | `--8dot <none|fast|basic|best|best-attr|best-trans>` | 8ドット2色アルゴリズムを選択。既定: `best`。 |
 | `--distance <rgb|hsb>` | パレット選択時の色距離計算方法。既定: `hsb`。 |
 | `--weight-h`, `--weight-s`, `--weight-b` | `hsb` 距離使用時の色相・彩度・明度の重み（0〜1）。 |

--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -30,6 +30,7 @@ struct CliOptions {
     bool use_dither{true};
     bool use_palette_color{false};
     bool use_dark_dither{true};
+    bool use_preprocess{true};
     int use_8dot2col{MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_BEST1};
     bool use_hsb{true};
     float weight_h{1.0f};
@@ -110,6 +111,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
                   << "  --color-system <msx1|msx2>   (デフォルト: msx1)\n"
                   << "  --dither / --no-dither       (デフォルト: dither)\n"
                   << "  --dark-dither / --no-dark-dither (デフォルト: ダークディザーパレットを使用)\n"
+                  << "  --no-preprocess             前処理をスキップ\n"
                   << "  --8dot <none|fast|basic|best|best-attr|best-trans> (デフォルト: best)\n"
                   << "  --distance <rgb|hsb>         (デフォルト: hsb)\n"
                   << "  --weight-h <0-1> --weight-s <0-1> --weight-b <0-1>\n"
@@ -141,6 +143,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
               << "  --dither / --no-dither       (default: dither)\n"
               << "  --palette92                  (for dev) Output 92 color palette without dithering\n"
               << "  --dark-dither / --no-dark-dither (default: use dark dither palettes)\n"
+              << "  --no-preprocess             Skip preprocessing adjustments\n"
               << "  --8dot <none|fast|basic|best|best-attr|best-trans> (default: best)\n"
               << "  --distance <rgb|hsb>         (default: hsb)\n"
               << "  --weight-h <0-1> --weight-s <0-1> --weight-b <0-1>\n"
@@ -222,6 +225,8 @@ bool parse_arguments(int argc, char** argv, CliOptions& opts) {
             opts.use_dark_dither = true;
         } else if (arg == "--no-dark-dither") {
             opts.use_dark_dither = false;
+        } else if (arg == "--no-preprocess") {
+            opts.use_preprocess = false;
         } else if (arg == "--8dot") {
             auto parsed = parse_8dot_mode(require_value(arg));
             if (!parsed) {
@@ -340,7 +345,9 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
             std::uint8_t g = px.green;
             std::uint8_t b = px.blue;
 
-            MSX1PQCore::apply_preprocess(&qi, r, g, b);
+            if (opts.use_preprocess) {
+                MSX1PQCore::apply_preprocess(&qi, r, g, b);
+            }
             const MSX1PQ::QuantColor& qc = MSX1PQCore::quantize_pixel(
                 qi,
                 r,


### PR DESCRIPTION
## Summary
- add a --no-preprocess flag to the CLI to bypass image preprocessing
- document the new flag in the built-in help text and CLI guides

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e33d9646c832488268f513f2abc37)