### PR TITLE
Update CLI docs for new output options

### DIFF
--- a/docs/CLI_guide_en.md
+++ b/docs/CLI_guide_en.md
@@ -29,6 +29,8 @@ The compiled binary will be placed at `platform\\Win\\x64\\msx1pq_cli.exe`.
 | `--input, -i <file|dir>` | Input PNG file or directory to process. |
 | `--output, -o <dir>` | Destination directory for converted PNG files. |
 | `--output-prefix <string>` | Prefix added to every output file name. |
+| `--out-sc5` | Save as SCREEN5 `.sc5` binary instead of PNG. |
+| `--out-sc2` | Save as SCREEN2 `.sc2` binary instead of PNG (requires `--8dot` set to anything other than `none`). |
 | `--color-system <msx1|msx2>` | Choose MSX1 (15 colors) or MSX2 palette. Default: `msx1`. |
 | `--dither` / `--no-dither` | Enable or disable dithering. Default: enabled. |
 | `--dark-dither` / `--no-dark-dither` | Use dedicated dark-area patterns or skip them. Default: enabled. |
@@ -48,6 +50,10 @@ The compiled binary will be placed at `platform\\Win\\x64\\msx1pq_cli.exe`.
 | `-h, --help` | Show help in the detected locale (Japanese if available). |
 | `--help-ja`, `--help-en` | Force Japanese or English help text. |
 
+Notes:
+- `--out-sc2` and `--out-sc5` cannot be used together. When either is specified the output extension changes to `.sc2` or `.sc5` respectively.
+- SCREEN2 export needs the 8-dot/2-color processing enabled (any `--8dot` value other than `none`).
+
 ### Examples
 
 Process one file into `dist/`:
@@ -66,4 +72,10 @@ Apply stronger saturation and the "best-attr" 8-dot algorithm:
 
 ```bash
 ./bin/msx1pq_cli -i shot.png -o dist --pre-sat 1.4 --8dot best-attr
+```
+
+Write a SCREEN5 binary for MSX emulators:
+
+```bash
+./bin/msx1pq_cli -i input.png -o dist --out-sc5 --color-system msx2
 ```

--- a/docs/CLI_guide_ja.md
+++ b/docs/CLI_guide_ja.md
@@ -29,6 +29,8 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 | `--input, -i <ファイル|ディレクトリ>` | 入力 PNG ファイルまたはディレクトリを指定。 |
 | `--output, -o <ディレクトリ>` | 変換結果を保存するディレクトリを指定。 |
 | `--output-prefix <文字列>` | 出力ファイル名の先頭に付与する接頭辞。 |
+| `--out-sc5` | PNG ではなく SCREEN5 の `.sc5` バイナリで書き出し。 |
+| `--out-sc2` | SCREEN2 の `.sc2` バイナリで書き出し（`--8dot` が `none` 以外であることが必要）。 |
 | `--color-system <msx1|msx2>` | MSX1（15色）か MSX2 パレットを選択。既定: `msx1`。 |
 | `--dither` / `--no-dither` | ディザリングの有無。既定: 有効。 |
 | `--dark-dither` / `--no-dark-dither` | 暗部専用ディザを使うか。既定: 有効。 |
@@ -48,6 +50,10 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 | `-h, --help` | ロケールに応じたヘルプを表示（日本語優先）。 |
 | `--help-ja`, `--help-en` | 日本語または英語のヘルプを強制表示。 |
 
+補足:
+- `--out-sc2` と `--out-sc5` は同時に指定できません。指定した場合、出力拡張子はそれぞれ `.sc2` / `.sc5` に変わります。
+- SCREEN2 での出力には 8dot 2色処理が必須です（`--8dot none` 以外の指定が必要）。
+
 ### 使用例
 
 単一ファイルを `dist/` に出力:
@@ -66,4 +72,10 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 
 ```bash
 ./bin/msx1pq_cli -i shot.png -o dist --pre-sat 1.4 --8dot best-attr
+```
+
+MSX エミュレーター向けに SCREEN5 バイナリを書き出す例:
+
+```bash
+./bin/msx1pq_cli -i input.png -o dist --out-sc5 --color-system msx2
 ```


### PR DESCRIPTION
## Summary
- document new SCREEN5/SCREEN2 output options for the CLI and note their constraints
- add examples showing how to emit SCREEN binaries from the CLI in both English and Japanese guides

## Testing
- Not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e3b1d99f883248de52206019b5e73)