### PR TITLE
Fix CLI guide option tables

### DIFF
--- a/docs/CLI_guide_en.md
+++ b/docs/CLI_guide_en.md
@@ -26,16 +26,16 @@ The compiled binary will be placed at `platform\\Win\\x64\\msx1pq_cli.exe`.
 
 | Option | Description |
 | --- | --- |
-| `--input, -i <file|dir>` | Input PNG file or directory to process. |
+| `--input, -i <file\|dir>` | Input PNG file or directory to process. |
 | `--output, -o <dir>` | Destination directory for converted PNG files. |
 | `--output-prefix <string>` | Prefix added to every output file name. |
 | `--out-sc5` | Save as SCREEN5 `.sc5` binary instead of PNG. |
 | `--out-sc2` | Save as SCREEN2 `.sc2` binary instead of PNG (requires `--8dot` set to anything other than `none`). |
-| `--color-system <msx1|msx2>` | Choose MSX1 (15 colors) or MSX2 palette. Default: `msx1`. |
+| `--color-system <msx1\|msx2>` | Choose MSX1 (15 colors) or MSX2 palette. Default: `msx1`. |
 | `--dither` / `--no-dither` | Enable or disable dithering. Default: enabled. |
 | `--dark-dither` / `--no-dark-dither` | Use dedicated dark-area patterns or skip them. Default: enabled. |
 | `--no-preprocess` | Skip all preprocessing tweaks (posterize, saturation, gamma, highlight, hue, LUT). |
-| `--8dot <none|fast|basic|best|best-attr|best-trans>` | Pick the 8-dot/2-color algorithm. Default: `best`. |
+| `--8dot <none\|fast\|basic\|best\|best-attr\|best-trans>` | Pick the 8-dot/2-color algorithm. Default: `best`. |
 | `--distance <rgb|hsb>` | Color distance mode for palette selection. Default: `hsb`. |
 | `--weight-h`, `--weight-s`, `--weight-b` | Weights (0–1) for hue, saturation, and brightness when `hsb` distance is selected. |
 | `--pre-posterize <0-255>` | Posterize before processing (default: `16`; skipped if `<=1`). |

--- a/docs/CLI_guide_ja.md
+++ b/docs/CLI_guide_ja.md
@@ -26,16 +26,16 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 
 | オプション | 説明 |
 | --- | --- |
-| `--input, -i <ファイル|ディレクトリ>` | 入力 PNG ファイルまたはディレクトリを指定。 |
+| `--input, -i <ファイル\|ディレクトリ>` | 入力 PNG ファイルまたはディレクトリを指定。 |
 | `--output, -o <ディレクトリ>` | 変換結果を保存するディレクトリを指定。 |
 | `--output-prefix <文字列>` | 出力ファイル名の先頭に付与する接頭辞。 |
 | `--out-sc5` | PNG ではなく SCREEN5 の `.sc5` バイナリで書き出し。 |
 | `--out-sc2` | SCREEN2 の `.sc2` バイナリで書き出し（`--8dot` が `none` 以外であることが必要）。 |
-| `--color-system <msx1|msx2>` | MSX1（15色）か MSX2 パレットを選択。既定: `msx1`。 |
+| `--color-system <msx1\|msx2>` | MSX1（15色）か MSX2 パレットを選択。既定: `msx1`。 |
 | `--dither` / `--no-dither` | ディザリングの有無。既定: 有効。 |
 | `--dark-dither` / `--no-dark-dither` | 暗部専用ディザを使うか。既定: 有効。 |
 | `--no-preprocess` | すべての前処理（ポスタリゼーション、彩度、ガンマ、ハイライト、色相、LUT）をスキップ。 |
-| `--8dot <none|fast|basic|best|best-attr|best-trans>` | 8ドット2色アルゴリズムを選択。既定: `best`。 |
+| `--8dot <none\|fast\|basic\|best\|best-attr\|best-trans>` | 8ドット2色アルゴリズムを選択。既定: `best`。 |
 | `--distance <rgb|hsb>` | パレット選択時の色距離計算方法。既定: `hsb`。 |
 | `--weight-h`, `--weight-s`, `--weight-b` | `hsb` 距離使用時の色相・彩度・明度の重み（0〜1）。 |
 | `--pre-posterize <0-255>` | 前処理でポスタリゼーションを適用（既定: `16`。`<=1` で無効）。 |


### PR DESCRIPTION
## Summary
- escape pipe characters inside CLI option values so the English and Japanese tables render correctly

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930e8c6585c8324906b0e20f38df2b3)