### PR TITLE
Add sharpness preprocessing option

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.h
+++ b/src/ae/MSX1PaletteQuantizer.h
@@ -37,6 +37,7 @@ enum MSX1PQ_ParamId {
     MSX1PQ_PARAM_PRE_GAMMA,       // Gamma to enhance shadows
     MSX1PQ_PARAM_PRE_HIGHLIGHT,   // Highlight correction
     MSX1PQ_PARAM_PRE_HUE,         // Hue rotation
+    MSX1PQ_PARAM_PRE_SHARPEN,     // Sharpen amount
 
     MSX1PQ_PARAM_USE_PALETTE_COLOR, // Use 92-color palette directly
 

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -43,6 +43,7 @@ struct QuantInfo {
     float pre_gamma{};
     float pre_highlight{};
     float pre_hue{};
+    float pre_sharpen{};
     bool  use_dark_dither{};
     int   color_system{MSX1PQ_COLOR_SYS_MSX1};
     const std::uint8_t* pre_lut{nullptr};


### PR DESCRIPTION
## Summary
- add a Lumetri-style preprocess sharpen slider to the effect UI and QuantInfo
- apply a 3x3 unsharp mask before quantization for AE/Premiere and CLI workflows
- expose a matching CLI option to drive the preprocessing sharpness

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931194b7e4c83248552467c6386928b)