### PR TITLE
Add sharpness preprocessing control

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.h
+++ b/src/ae/MSX1PaletteQuantizer.h
@@ -37,6 +37,7 @@ enum MSX1PQ_ParamId {
     MSX1PQ_PARAM_PRE_GAMMA,       // Gamma to enhance shadows
     MSX1PQ_PARAM_PRE_HIGHLIGHT,   // Highlight correction
     MSX1PQ_PARAM_PRE_HUE,         // Hue rotation
+    MSX1PQ_PARAM_PRE_SHARPNESS,   // Sharpen amount
 
     MSX1PQ_PARAM_USE_PALETTE_COLOR, // Use 92-color palette directly
 

--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -41,6 +41,7 @@ struct CliOptions {
     float pre_gamma{1.0f};
     float pre_highlight{1.0f};
     float pre_hue{0.0f};
+    float pre_sharpness{0.0f};
     fs::path pre_lut_path;
     std::vector<std::uint8_t> pre_lut_data;
     std::vector<float> pre_lut3d_data;
@@ -120,6 +121,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
                   << "  --pre-gamma <0-10>           処理前にガンマを暗く補正 (デフォルト: 1.0)\n"
                   << "  --pre-highlight <0-10>       処理前にハイライトを明るく補正 (デフォルト: 1.0)\n"
                   << "  --pre-hue <-180-180>         処理前に色相を変更 (デフォルト: 0.0)\n"
+                  << "  --pre-sharpness <0-1>        処理前にシャープネスを適用 (デフォルト: 0.0)\n"
                   << "  --pre-lut <ファイル>           処理前にRGB LUT(256行のRGB値)や.cube 3D LUTを適用\n"
                   << "  --palette92                  (開発用) ディザ処理を行わず92色パレットで出力\n"
                   << "  -f, --force                  上書き時に確認しない\n"
@@ -152,6 +154,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
               << "  --pre-gamma <0-10>           Darken gamma before processing (default: 1.0)\n"
               << "  --pre-highlight <0-10>       Brighten highlights before processing (default: 1.0)\n"
               << "  --pre-hue <-180-180>         Adjust hue before processing (default: 0.0)\n"
+              << "  --pre-sharpness <0-1>        Apply sharpening before processing (default: 0.0)\n"
               << "  --pre-lut <file>             Apply RGB LUT (256 rows) or .cube 3D LUT before processing\n"
               << "  -f, --force                  Overwrite without confirmation\n"
               << "  -v, --version                Show version information\n"
@@ -258,6 +261,8 @@ bool parse_arguments(int argc, char** argv, CliOptions& opts) {
             opts.pre_highlight = std::stof(require_value(arg));
         } else if (arg == "--pre-hue") {
             opts.pre_hue = std::stof(require_value(arg));
+        } else if (arg == "--pre-sharpness") {
+            opts.pre_sharpness = std::stof(require_value(arg));
         } else if (arg == "--pre-lut") {
             opts.pre_lut_path = require_value(arg);
         } else if (arg == "--force" || arg == "-f") {
@@ -332,11 +337,19 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
     qi.pre_gamma       = opts.pre_gamma;
     qi.pre_highlight   = opts.pre_highlight;
     qi.pre_hue         = opts.pre_hue;
+    qi.pre_sharpness   = MSX1PQCore::clamp01f(opts.pre_sharpness);
     qi.use_dark_dither = opts.use_dark_dither;
     qi.color_system    = opts.color_system;
     qi.pre_lut         = opts.pre_lut_data.empty() ? nullptr : opts.pre_lut_data.data();
     qi.pre_lut3d       = opts.pre_lut3d_data.empty() ? nullptr : opts.pre_lut3d_data.data();
     qi.pre_lut3d_size  = opts.pre_lut3d_size;
+
+    if (opts.use_preprocess && qi.pre_sharpness > 0.0f) {
+        const std::ptrdiff_t pitch = static_cast<std::ptrdiff_t>(width);
+        const std::int32_t w = static_cast<std::int32_t>(width);
+        const std::int32_t h = static_cast<std::int32_t>(height);
+        MSX1PQCore::apply_sharpness_3x3(pixels.data(), pitch, w, h, qi.pre_sharpness);
+    }
 
     for (unsigned y = 0; y < height; ++y) {
         for (unsigned x = 0; x < width; ++x) {

--- a/src/core/MSX1PQCore.cpp
+++ b/src/core/MSX1PQCore.cpp
@@ -129,6 +129,30 @@ float clamp01f(float v)
     return v;
 }
 
+void apply_sharpness_rgb(float amount,
+                         std::uint8_t blurred_r,
+                         std::uint8_t blurred_g,
+                         std::uint8_t blurred_b,
+                         std::uint8_t &r8,
+                         std::uint8_t &g8,
+                         std::uint8_t &b8)
+{
+    amount = clamp01f(amount);
+    if (amount <= 0.0f) {
+        return;
+    }
+
+    auto sharpen = [amount](std::uint8_t src, std::uint8_t blurred) {
+        float delta = static_cast<float>(src) - static_cast<float>(blurred);
+        float value = static_cast<float>(src) + delta * (1.5f * amount);
+        return clamp_value<int>(static_cast<int>(std::round(value)), 0, 255);
+    };
+
+    r8 = static_cast<std::uint8_t>(sharpen(r8, blurred_r));
+    g8 = static_cast<std::uint8_t>(sharpen(g8, blurred_g));
+    b8 = static_cast<std::uint8_t>(sharpen(b8, blurred_b));
+}
+
 bool load_pre_lut(const std::string& path,
                   std::vector<std::uint8_t>& out1d,
                   std::vector<float>& out3d,


### PR DESCRIPTION
## Summary
- add core sharpness helpers for a Lumetri-style 3x3 sharpening pass
- expose 0–1 sharpness controls in the CLI and AE/Premiere parameters
- run sharpening on source pixels before existing preprocessing and quantization

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a314a67c83248d7735ee0198ff0c)