### PR TITLE
Add output suffix CLI option and rename prefix flag

### DIFF
--- a/docs/CLI_guide_en.md
+++ b/docs/CLI_guide_en.md
@@ -28,7 +28,8 @@ The compiled binary will be placed at `platform\\Win\\x64\\msx1pq_cli.exe`.
 | --- | --- |
 | `--input, -i <file\|dir>` | Input PNG file or directory to process. |
 | `--output, -o <dir>` | Destination directory for converted PNG files. |
-| `--output-prefix <string>` | Prefix added to every output file name. |
+| `--out-prefix <string>` | Prefix added to every output file name. |
+| `--out-suffix <string>` | Suffix inserted before the output file extension. |
 | `--out-sc5` | Save as SCREEN5 `.sc5` binary instead of PNG. |
 | `--out-sc2` | Save as SCREEN2 `.sc2` binary instead of PNG (requires `--8dot` set to anything other than `none`). |
 | `--color-system <msx1\|msx2>` | Choose MSX1 (15 colors) or MSX2 palette. Default: `msx1`. |

--- a/docs/CLI_guide_ja.md
+++ b/docs/CLI_guide_ja.md
@@ -28,7 +28,8 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 | --- | --- |
 | `--input, -i <ファイル\|ディレクトリ>` | 入力 PNG ファイルまたはディレクトリを指定。 |
 | `--output, -o <ディレクトリ>` | 変換結果を保存するディレクトリを指定。 |
-| `--output-prefix <文字列>` | 出力ファイル名の先頭に付与する接頭辞。 |
+| `--out-prefix <文字列>` | 出力ファイル名の先頭に付与する接頭辞。 |
+| `--out-suffix <文字列>` | 出力ファイル名の末尾（拡張子の前）に付与する接尾辞。 |
 | `--out-sc5` | PNG ではなく SCREEN5 の `.sc5` バイナリで書き出し。 |
 | `--out-sc2` | SCREEN2 の `.sc2` バイナリで書き出し（`--8dot` が `none` 以外であることが必要）。 |
 | `--color-system <msx1\|msx2>` | MSX1（15色）か MSX2 パレットを選択。既定: `msx1`。 |

--- a/tools/disit_items/run_batch_pipeline.bat
+++ b/tools/disit_items/run_batch_pipeline.bat
@@ -3,8 +3,8 @@ setlocal enabledelayedexpansion
 
 :: Batch runner for chaining multiple msx1pq_cli.exe calls against a dropped file or folder.
 if "%~1"=="" (
-    echo gp@: ﾌバb`t@Cﾉフ@CﾜはフH_[hbOhbvﾄ�B
-    echo ﾍフ@CitH_jﾉ対て異なＱ[^[ 10 msxGtFNgKpﾜ�B
+    echo 使用法: このバッチファイルにファイルまたはフォルダーをドラッグ＆ドロップしてください。
+    echo 入力ファイル（フォルダ）に対して異なるパラメーターで 10回の msxエフェクトを適用します。
     echo Usage: Drag and drop a file or folder onto this batch file.
     echo The script will run 10 msx1pq_cli.exe commands with varied parameters against the input.
     exit /b 1

--- a/tools/disit_items/run_batch_pipeline.bat
+++ b/tools/disit_items/run_batch_pipeline.bat
@@ -3,8 +3,8 @@ setlocal enabledelayedexpansion
 
 :: Batch runner for chaining multiple msx1pq_cli.exe calls against a dropped file or folder.
 if "%~1"=="" (
-    echo 使用法: このバッチファイルにファイルまたはフォルダーをドラッグ＆ドロップしてください。
-    echo 入力ファイル（フォルダ）に対して異なるパラメーターで 10回の msxエフェクトを適用します。
+    echo gp@: ﾌバb`t@Cﾉフ@CﾜはフH_[hbOhbvﾄ�B
+    echo ﾍフ@CitH_jﾉ対て異なＱ[^[ 10 msxGtFNgKpﾜ�B
     echo Usage: Drag and drop a file or folder onto this batch file.
     echo The script will run 10 msx1pq_cli.exe commands with varied parameters against the input.
     exit /b 1
@@ -27,25 +27,25 @@ cd /d %SCRIPT_DIR%
 echo Processing "%INPUT_PATH%"...
 echo
 
-msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --output-prefix "01_fast_" --pre-sat 1.35 --pre-highlight 1.15 --force
+msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --out-prefix "01_fast_" --pre-sat 1.35 --pre-highlight 1.15 --force
 if errorlevel 1 goto :abort
-msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --output-prefix "02_msx2_" --color-system msx2 --pre-highlight 1.3 --force
+msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --out-prefix "02_msx2_" --color-system msx2 --pre-highlight 1.3 --force
 if errorlevel 1 goto :abort
-msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --output-prefix "03_hsb_" --weight-h 0.4 --weight-s 0.95 --weight-b 0.65 --force
+msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --out-prefix "03_hsb_" --weight-h 0.4 --weight-s 0.95 --weight-b 0.65 --force
 if errorlevel 1 goto :abort
-msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --output-prefix "04_rgb_" --distance rgb --pre-highlight 1.5 --pre-sat 1.2 --force
+msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --out-prefix "04_rgb_" --distance rgb --pre-highlight 1.5 --pre-sat 1.2 --force
 if errorlevel 1 goto :abort
-msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --output-prefix "05_fast8dot_" --8dot fast --no-dark-dither --pre-gamma 0.7 --pre-sat 1.25 --force
+msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --out-prefix "05_fast8dot_" --8dot fast --no-dark-dither --pre-gamma 0.7 --pre-sat 1.25 --force
 if errorlevel 1 goto :abort
-msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --output-prefix "06_best_" --8dot best --pre-sat 1.7 --pre-highlight 1.25 --force
+msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --out-prefix "06_best_" --8dot best --pre-sat 1.7 --pre-highlight 1.25 --force
 if errorlevel 1 goto :abort
-msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --output-prefix "07_poster_" --pre-posterize 10 --pre-gamma 1.3 --pre-hue 8 --force
+msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --out-prefix "07_poster_" --pre-posterize 10 --pre-gamma 1.3 --pre-hue 8 --force
 if errorlevel 1 goto :abort
-msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --output-prefix "08_moody_" --pre-gamma 1.4 --pre-sat 0.75 --pre-highlight 0.6 --force
+msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --out-prefix "08_moody_" --pre-gamma 1.4 --pre-sat 0.75 --pre-highlight 0.6 --force
 if errorlevel 1 goto :abort
-msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --output-prefix "09_clean_" --no-dither --pre-posterize 24 --pre-hue -12 --force
+msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --out-prefix "09_clean_" --no-dither --pre-posterize 24 --pre-hue -12 --force
 if errorlevel 1 goto :abort
-msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --output-prefix "10_lut_" --pre-lut "%LUT_PATH%" --force
+msx1pq_cli.exe --input "%INPUT_PATH%" --output "%OUTPUT_DIR%" --out-prefix "10_lut_" --pre-lut "%LUT_PATH%" --force
 if errorlevel 1 goto :abort
 
 


### PR DESCRIPTION
## Summary
- rename the CLI prefix flag to `--out-prefix` and document the new naming
- add a new `--out-suffix` option to append text before output extensions
- refresh documentation and batch examples to use the updated options

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693250f3c4e483249bdb80523a79e2d4)