### PR TITLE
Apply sharpening only near black areas

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -364,9 +364,9 @@ ParamsSetup (
     PF_ADD_FLOAT_SLIDERX(
         "Pre 6: Sharpness",
         0,
-        1,
+        10,
         0,
-        1,
+        10,
         0,
         2,
         0,
@@ -779,7 +779,10 @@ Render (
     qi.pre_gamma     = static_cast<float>(params[MSX1PQ_PARAM_PRE_GAMMA]->u.fs_d.value);
     qi.pre_highlight = static_cast<float>(params[MSX1PQ_PARAM_PRE_HIGHLIGHT]->u.fs_d.value);
     qi.pre_hue       = static_cast<float>(params[MSX1PQ_PARAM_PRE_HUE]->u.fs_d.value);
-    qi.pre_sharpness = clamp01f(static_cast<float>(params[MSX1PQ_PARAM_PRE_SHARPNESS]->u.fs_d.value));
+    qi.pre_sharpness = clamp_value(
+        static_cast<float>(params[MSX1PQ_PARAM_PRE_SHARPNESS]->u.fs_d.value),
+        0.0f,
+        10.0f);
     qi.pre_sharpness_black_threshold = clamp_value(
         static_cast<int>(params[MSX1PQ_PARAM_PRE_SHARP_THRESHOLD]->u.fs_d.value + 0.5f),
         0,

--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -375,6 +375,20 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    PF_ADD_FLOAT_SLIDERX(
+        "Pre 6b: Sharp threshold",
+        0,
+        255,
+        0,
+        255,
+        48,
+        0,
+        0,
+        0,
+        MSX1PQ_PARAM_PRE_SHARP_THRESHOLD
+    );
+
+    AEFX_CLR_STRUCT(def);
     def.flags    |= PF_ParamFlag_CANNOT_TIME_VARY;
     PF_ADD_CHECKBOX(
         "92-color",
@@ -537,6 +551,7 @@ FilterImage8 (
         std::uint8_t blurred_b = static_cast<std::uint8_t>(sum_b / 9);
 
         MSX1PQCore::apply_sharpness_rgb(qi->pre_sharpness,
+                                        static_cast<std::uint8_t>(qi->pre_sharpness_black_threshold),
                                         blurred_r, blurred_g, blurred_b,
                                         r, g, b);
     }
@@ -614,6 +629,7 @@ FilterImageBGRA_8u (
         std::uint8_t blurred_b = static_cast<std::uint8_t>(sum_b / 9);
 
         MSX1PQCore::apply_sharpness_rgb(qi->pre_sharpness,
+                                        static_cast<std::uint8_t>(qi->pre_sharpness_black_threshold),
                                         blurred_r, blurred_g, blurred_b,
                                         r, g, b);
     }
@@ -764,6 +780,10 @@ Render (
     qi.pre_highlight = static_cast<float>(params[MSX1PQ_PARAM_PRE_HIGHLIGHT]->u.fs_d.value);
     qi.pre_hue       = static_cast<float>(params[MSX1PQ_PARAM_PRE_HUE]->u.fs_d.value);
     qi.pre_sharpness = clamp01f(static_cast<float>(params[MSX1PQ_PARAM_PRE_SHARPNESS]->u.fs_d.value));
+    qi.pre_sharpness_black_threshold = clamp_value(
+        static_cast<int>(params[MSX1PQ_PARAM_PRE_SHARP_THRESHOLD]->u.fs_d.value + 0.5f),
+        0,
+        255);
 
     qi.use_dark_dither = (params[MSX1PQ_PARAM_USE_DARK_DITHER]->u.bd.value != 0);
 
@@ -1151,6 +1171,16 @@ SmartRender(
                 MSX1PQ_PARAM_PRE_SHARPNESS,
                 param) );
         qi.pre_sharpness = clamp01f(static_cast<float>(param.u.fs_d.value));
+        ERR( CheckinParam(in_dataP, param) );
+
+        ERR( CheckoutParam(
+                in_dataP,
+                MSX1PQ_PARAM_PRE_SHARP_THRESHOLD,
+                param) );
+        qi.pre_sharpness_black_threshold = clamp_value(
+            static_cast<int>(param.u.fs_d.value + 0.5f),
+            0,
+            255);
         ERR( CheckinParam(in_dataP, param) );
 
         // USE_DARK_DITHER

--- a/src/ae/MSX1PaletteQuantizer.h
+++ b/src/ae/MSX1PaletteQuantizer.h
@@ -38,6 +38,7 @@ enum MSX1PQ_ParamId {
     MSX1PQ_PARAM_PRE_HIGHLIGHT,   // Highlight correction
     MSX1PQ_PARAM_PRE_HUE,         // Hue rotation
     MSX1PQ_PARAM_PRE_SHARPNESS,   // Sharpen amount
+    MSX1PQ_PARAM_PRE_SHARP_THRESHOLD, // Black-level threshold for sharpening
 
     MSX1PQ_PARAM_USE_PALETTE_COLOR, // Use 92-color palette directly
 

--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -124,7 +124,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
                   << "  --pre-gamma <0-10>           処理前にガンマを暗く補正 (デフォルト: 1.0)\n"
                   << "  --pre-highlight <0-10>       処理前にハイライトを明るく補正 (デフォルト: 1.0)\n"
                   << "  --pre-hue <-180-180>         処理前に色相を変更 (デフォルト: 0.0)\n"
-                  << "  --pre-sharpness <0-1>        処理前にシャープネスを適用 (デフォルト: 0.0)\n"
+                  << "  --pre-sharpness <0-10>       処理前にシャープネスを適用 (デフォルト: 0.0)\n"
                   << "  --pre-sharpness-threshold <0-255> 黒付近のみシャープ化する際のしきい値 (デフォルト: 48)\n"
                   << "  --pre-lut <ファイル>           処理前にRGB LUT(256行のRGB値)や.cube 3D LUTを適用\n"
                   << "  --palette92                  (開発用) ディザ処理を行わず92色パレットで出力\n"
@@ -159,7 +159,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
               << "  --pre-gamma <0-10>           Darken gamma before processing (default: 1.0)\n"
               << "  --pre-highlight <0-10>       Brighten highlights before processing (default: 1.0)\n"
               << "  --pre-hue <-180-180>         Adjust hue before processing (default: 0.0)\n"
-              << "  --pre-sharpness <0-1>        Apply sharpening before processing (default: 0.0)\n"
+              << "  --pre-sharpness <0-10>       Apply sharpening before processing (default: 0.0)\n"
               << "  --pre-sharpness-threshold <0-255> Threshold for black-only sharpening (default: 48)\n"
               << "  --pre-lut <file>             Apply RGB LUT (256 rows) or .cube 3D LUT before processing\n"
               << "  -f, --force                  Overwrite without confirmation\n"
@@ -347,7 +347,7 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
     qi.pre_gamma       = opts.pre_gamma;
     qi.pre_highlight   = opts.pre_highlight;
     qi.pre_hue         = opts.pre_hue;
-    qi.pre_sharpness   = MSX1PQCore::clamp01f(opts.pre_sharpness);
+    qi.pre_sharpness   = MSX1PQCore::clamp_value(opts.pre_sharpness, 0.0f, 10.0f);
     qi.pre_sharpness_black_threshold = MSX1PQCore::clamp_value(
         opts.pre_sharpness_black_threshold,
         0,

--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -43,6 +43,7 @@ struct CliOptions {
     float pre_highlight{1.0f};
     float pre_hue{0.0f};
     float pre_sharpness{0.0f};
+    int pre_sharpness_black_threshold{48};
     fs::path pre_lut_path;
     std::vector<std::uint8_t> pre_lut_data;
     std::vector<float> pre_lut3d_data;
@@ -124,6 +125,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
                   << "  --pre-highlight <0-10>       処理前にハイライトを明るく補正 (デフォルト: 1.0)\n"
                   << "  --pre-hue <-180-180>         処理前に色相を変更 (デフォルト: 0.0)\n"
                   << "  --pre-sharpness <0-1>        処理前にシャープネスを適用 (デフォルト: 0.0)\n"
+                  << "  --pre-sharpness-threshold <0-255> 黒付近のみシャープ化する際のしきい値 (デフォルト: 48)\n"
                   << "  --pre-lut <ファイル>           処理前にRGB LUT(256行のRGB値)や.cube 3D LUTを適用\n"
                   << "  --palette92                  (開発用) ディザ処理を行わず92色パレットで出力\n"
                   << "  -f, --force                  上書き時に確認しない\n"
@@ -158,6 +160,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
               << "  --pre-highlight <0-10>       Brighten highlights before processing (default: 1.0)\n"
               << "  --pre-hue <-180-180>         Adjust hue before processing (default: 0.0)\n"
               << "  --pre-sharpness <0-1>        Apply sharpening before processing (default: 0.0)\n"
+              << "  --pre-sharpness-threshold <0-255> Threshold for black-only sharpening (default: 48)\n"
               << "  --pre-lut <file>             Apply RGB LUT (256 rows) or .cube 3D LUT before processing\n"
               << "  -f, --force                  Overwrite without confirmation\n"
               << "  -v, --version                Show version information\n"
@@ -268,6 +271,8 @@ bool parse_arguments(int argc, char** argv, CliOptions& opts) {
             opts.pre_hue = std::stof(require_value(arg));
         } else if (arg == "--pre-sharpness") {
             opts.pre_sharpness = std::stof(require_value(arg));
+        } else if (arg == "--pre-sharpness-threshold") {
+            opts.pre_sharpness_black_threshold = std::stoi(require_value(arg));
         } else if (arg == "--pre-lut") {
             opts.pre_lut_path = require_value(arg);
         } else if (arg == "--force" || arg == "-f") {
@@ -343,6 +348,10 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
     qi.pre_highlight   = opts.pre_highlight;
     qi.pre_hue         = opts.pre_hue;
     qi.pre_sharpness   = MSX1PQCore::clamp01f(opts.pre_sharpness);
+    qi.pre_sharpness_black_threshold = MSX1PQCore::clamp_value(
+        opts.pre_sharpness_black_threshold,
+        0,
+        255);
     qi.use_dark_dither = opts.use_dark_dither;
     qi.color_system    = opts.color_system;
     qi.pre_lut         = opts.pre_lut_data.empty() ? nullptr : opts.pre_lut_data.data();
@@ -353,7 +362,13 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
         const std::ptrdiff_t pitch = static_cast<std::ptrdiff_t>(width);
         const std::int32_t w = static_cast<std::int32_t>(width);
         const std::int32_t h = static_cast<std::int32_t>(height);
-        MSX1PQCore::apply_sharpness_3x3(pixels.data(), pitch, w, h, qi.pre_sharpness);
+        MSX1PQCore::apply_sharpness_3x3(
+            pixels.data(),
+            pitch,
+            w,
+            h,
+            qi.pre_sharpness,
+            static_cast<std::uint8_t>(qi.pre_sharpness_black_threshold));
     }
 
     for (unsigned y = 0; y < height; ++y) {

--- a/src/core/MSX1PQCore.cpp
+++ b/src/core/MSX1PQCore.cpp
@@ -142,6 +142,13 @@ void apply_sharpness_rgb(float amount,
         return;
     }
 
+    // 黒付近のみシャープ化を適用する（黒辺の強調用）
+    constexpr std::uint8_t kBlackThreshold = 48; // 0x30 相当の暗さまで
+    const std::uint8_t blurred_max = std::max({blurred_r, blurred_g, blurred_b});
+    if (blurred_max > kBlackThreshold) {
+        return;
+    }
+
     auto sharpen = [amount](std::uint8_t src, std::uint8_t blurred) {
         float delta = static_cast<float>(src) - static_cast<float>(blurred);
         float value = static_cast<float>(src) + delta * (1.5f * amount);

--- a/src/core/MSX1PQCore.cpp
+++ b/src/core/MSX1PQCore.cpp
@@ -129,6 +129,13 @@ float clamp01f(float v)
     return v;
 }
 
+static float clamp_sharp_amount(float v)
+{
+    if (v < 0.0f) return 0.0f;
+    if (v > 10.0f) return 10.0f;
+    return v;
+}
+
 void apply_sharpness_rgb(float amount,
                          std::uint8_t black_threshold,
                          std::uint8_t blurred_r,
@@ -138,7 +145,7 @@ void apply_sharpness_rgb(float amount,
                          std::uint8_t &g8,
                          std::uint8_t &b8)
 {
-    amount = clamp01f(amount);
+    amount = clamp_sharp_amount(amount);
     if (amount <= 0.0f) {
         return;
     }

--- a/src/core/MSX1PQCore.cpp
+++ b/src/core/MSX1PQCore.cpp
@@ -130,6 +130,7 @@ float clamp01f(float v)
 }
 
 void apply_sharpness_rgb(float amount,
+                         std::uint8_t black_threshold,
                          std::uint8_t blurred_r,
                          std::uint8_t blurred_g,
                          std::uint8_t blurred_b,
@@ -143,9 +144,8 @@ void apply_sharpness_rgb(float amount,
     }
 
     // 黒付近のみシャープ化を適用する（黒辺の強調用）
-    constexpr std::uint8_t kBlackThreshold = 48; // 0x30 相当の暗さまで
     const std::uint8_t blurred_max = std::max({blurred_r, blurred_g, blurred_b});
-    if (blurred_max > kBlackThreshold) {
+    if (blurred_max > black_threshold) {
         return;
     }
 

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -45,6 +45,7 @@ struct QuantInfo {
     float pre_highlight{};
     float pre_hue{};
     float pre_sharpness{};
+    int   pre_sharpness_black_threshold{48};
     bool  use_dark_dither{};
     int   color_system{MSX1PQ_COLOR_SYS_MSX1};
     const std::uint8_t* pre_lut{nullptr};
@@ -77,6 +78,7 @@ void apply_preprocess(const QuantInfo *qi,
                       std::uint8_t &b8);
 
 void apply_sharpness_rgb(float amount,
+                         std::uint8_t black_threshold,
                          std::uint8_t blurred_r,
                          std::uint8_t blurred_g,
                          std::uint8_t blurred_b,
@@ -90,7 +92,8 @@ void apply_sharpness_3x3(
     std::ptrdiff_t row_pitch,
     std::int32_t width,
     std::int32_t height,
-    float amount)
+    float amount,
+    std::uint8_t black_threshold)
 {
     if (!data || width <= 0 || height <= 0) {
         return;
@@ -137,7 +140,9 @@ void apply_sharpness_3x3(
             std::uint8_t blurred_b = static_cast<std::uint8_t>(sum_b / 9);
 
             PixelT& dst = row[x];
-            apply_sharpness_rgb(amount, blurred_r, blurred_g, blurred_b,
+            apply_sharpness_rgb(amount,
+                                black_threshold,
+                                blurred_r, blurred_g, blurred_b,
                                 dst.red, dst.green, dst.blue);
         }
     }

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -99,7 +99,7 @@ void apply_sharpness_3x3(
         return;
     }
 
-    amount = clamp01f(amount);
+    amount = clamp_value(amount, 0.0f, 10.0f);
     if (amount <= 0.0f) {
         return;
     }


### PR DESCRIPTION
## Summary
- limit sharpening to areas near black content by checking blurred pixel intensity
- keep bright regions untouched when pre-sharpening is enabled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932caae411883248fb138357b3e793c)