### PR TITLE
Align sharpening behavior with Lumetri and remove threshold controls

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -375,20 +375,6 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
-    PF_ADD_FLOAT_SLIDERX(
-        "Pre 6b: Sharp threshold",
-        0,
-        255,
-        0,
-        255,
-        48,
-        0,
-        0,
-        0,
-        MSX1PQ_PARAM_PRE_SHARP_THRESHOLD
-    );
-
-    AEFX_CLR_STRUCT(def);
     def.flags    |= PF_ParamFlag_CANNOT_TIME_VARY;
     PF_ADD_CHECKBOX(
         "92-color",
@@ -551,7 +537,6 @@ FilterImage8 (
         std::uint8_t blurred_b = static_cast<std::uint8_t>(sum_b / 9);
 
         MSX1PQCore::apply_sharpness_rgb(qi->pre_sharpness,
-                                        static_cast<std::uint8_t>(qi->pre_sharpness_black_threshold),
                                         blurred_r, blurred_g, blurred_b,
                                         r, g, b);
     }
@@ -629,7 +614,6 @@ FilterImageBGRA_8u (
         std::uint8_t blurred_b = static_cast<std::uint8_t>(sum_b / 9);
 
         MSX1PQCore::apply_sharpness_rgb(qi->pre_sharpness,
-                                        static_cast<std::uint8_t>(qi->pre_sharpness_black_threshold),
                                         blurred_r, blurred_g, blurred_b,
                                         r, g, b);
     }
@@ -783,10 +767,6 @@ Render (
         static_cast<float>(params[MSX1PQ_PARAM_PRE_SHARPNESS]->u.fs_d.value),
         0.0f,
         10.0f);
-    qi.pre_sharpness_black_threshold = clamp_value(
-        static_cast<int>(params[MSX1PQ_PARAM_PRE_SHARP_THRESHOLD]->u.fs_d.value + 0.5f),
-        0,
-        255);
 
     qi.use_dark_dither = (params[MSX1PQ_PARAM_USE_DARK_DITHER]->u.bd.value != 0);
 
@@ -1174,16 +1154,6 @@ SmartRender(
                 MSX1PQ_PARAM_PRE_SHARPNESS,
                 param) );
         qi.pre_sharpness = clamp01f(static_cast<float>(param.u.fs_d.value));
-        ERR( CheckinParam(in_dataP, param) );
-
-        ERR( CheckoutParam(
-                in_dataP,
-                MSX1PQ_PARAM_PRE_SHARP_THRESHOLD,
-                param) );
-        qi.pre_sharpness_black_threshold = clamp_value(
-            static_cast<int>(param.u.fs_d.value + 0.5f),
-            0,
-            255);
         ERR( CheckinParam(in_dataP, param) );
 
         // USE_DARK_DITHER

--- a/src/ae/MSX1PaletteQuantizer.h
+++ b/src/ae/MSX1PaletteQuantizer.h
@@ -38,7 +38,6 @@ enum MSX1PQ_ParamId {
     MSX1PQ_PARAM_PRE_HIGHLIGHT,   // Highlight correction
     MSX1PQ_PARAM_PRE_HUE,         // Hue rotation
     MSX1PQ_PARAM_PRE_SHARPNESS,   // Sharpen amount
-    MSX1PQ_PARAM_PRE_SHARP_THRESHOLD, // Black-level threshold for sharpening
 
     MSX1PQ_PARAM_USE_PALETTE_COLOR, // Use 92-color palette directly
 

--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -43,7 +43,6 @@ struct CliOptions {
     float pre_highlight{1.0f};
     float pre_hue{0.0f};
     float pre_sharpness{0.0f};
-    int pre_sharpness_black_threshold{48};
     fs::path pre_lut_path;
     std::vector<std::uint8_t> pre_lut_data;
     std::vector<float> pre_lut3d_data;
@@ -125,7 +124,6 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
                   << "  --pre-highlight <0-10>       処理前にハイライトを明るく補正 (デフォルト: 1.0)\n"
                   << "  --pre-hue <-180-180>         処理前に色相を変更 (デフォルト: 0.0)\n"
                   << "  --pre-sharpness <0-10>       処理前にシャープネスを適用 (デフォルト: 0.0)\n"
-                  << "  --pre-sharpness-threshold <0-255> 黒付近のみシャープ化する際のしきい値 (デフォルト: 48)\n"
                   << "  --pre-lut <ファイル>           処理前にRGB LUT(256行のRGB値)や.cube 3D LUTを適用\n"
                   << "  --palette92                  (開発用) ディザ処理を行わず92色パレットで出力\n"
                   << "  -f, --force                  上書き時に確認しない\n"
@@ -160,7 +158,6 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
               << "  --pre-highlight <0-10>       Brighten highlights before processing (default: 1.0)\n"
               << "  --pre-hue <-180-180>         Adjust hue before processing (default: 0.0)\n"
               << "  --pre-sharpness <0-10>       Apply sharpening before processing (default: 0.0)\n"
-              << "  --pre-sharpness-threshold <0-255> Threshold for black-only sharpening (default: 48)\n"
               << "  --pre-lut <file>             Apply RGB LUT (256 rows) or .cube 3D LUT before processing\n"
               << "  -f, --force                  Overwrite without confirmation\n"
               << "  -v, --version                Show version information\n"
@@ -271,8 +268,6 @@ bool parse_arguments(int argc, char** argv, CliOptions& opts) {
             opts.pre_hue = std::stof(require_value(arg));
         } else if (arg == "--pre-sharpness") {
             opts.pre_sharpness = std::stof(require_value(arg));
-        } else if (arg == "--pre-sharpness-threshold") {
-            opts.pre_sharpness_black_threshold = std::stoi(require_value(arg));
         } else if (arg == "--pre-lut") {
             opts.pre_lut_path = require_value(arg);
         } else if (arg == "--force" || arg == "-f") {
@@ -348,10 +343,6 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
     qi.pre_highlight   = opts.pre_highlight;
     qi.pre_hue         = opts.pre_hue;
     qi.pre_sharpness   = MSX1PQCore::clamp_value(opts.pre_sharpness, 0.0f, 10.0f);
-    qi.pre_sharpness_black_threshold = MSX1PQCore::clamp_value(
-        opts.pre_sharpness_black_threshold,
-        0,
-        255);
     qi.use_dark_dither = opts.use_dark_dither;
     qi.color_system    = opts.color_system;
     qi.pre_lut         = opts.pre_lut_data.empty() ? nullptr : opts.pre_lut_data.data();
@@ -367,8 +358,7 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
             pitch,
             w,
             h,
-            qi.pre_sharpness,
-            static_cast<std::uint8_t>(qi.pre_sharpness_black_threshold));
+            qi.pre_sharpness);
     }
 
     for (unsigned y = 0; y < height; ++y) {

--- a/src/core/MSX1PQCore.cpp
+++ b/src/core/MSX1PQCore.cpp
@@ -137,7 +137,6 @@ static float clamp_sharp_amount(float v)
 }
 
 void apply_sharpness_rgb(float amount,
-                         std::uint8_t black_threshold,
                          std::uint8_t blurred_r,
                          std::uint8_t blurred_g,
                          std::uint8_t blurred_b,
@@ -150,12 +149,8 @@ void apply_sharpness_rgb(float amount,
         return;
     }
 
-    // 黒付近のみシャープ化を適用する（黒辺の強調用）
-    const std::uint8_t blurred_max = std::max({blurred_r, blurred_g, blurred_b});
-    if (blurred_max > black_threshold) {
-        return;
-    }
-
+    // Lumetri 相当の単純なアンシャープマスクを全画素に適用する
+    // （黒限定の特殊処理は行わない）
     auto sharpen = [amount](std::uint8_t src, std::uint8_t blurred) {
         float delta = static_cast<float>(src) - static_cast<float>(blurred);
         float value = static_cast<float>(src) + delta * (1.5f * amount);

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -45,7 +45,6 @@ struct QuantInfo {
     float pre_highlight{};
     float pre_hue{};
     float pre_sharpness{};
-    int   pre_sharpness_black_threshold{48};
     bool  use_dark_dither{};
     int   color_system{MSX1PQ_COLOR_SYS_MSX1};
     const std::uint8_t* pre_lut{nullptr};
@@ -78,7 +77,6 @@ void apply_preprocess(const QuantInfo *qi,
                       std::uint8_t &b8);
 
 void apply_sharpness_rgb(float amount,
-                         std::uint8_t black_threshold,
                          std::uint8_t blurred_r,
                          std::uint8_t blurred_g,
                          std::uint8_t blurred_b,
@@ -92,8 +90,7 @@ void apply_sharpness_3x3(
     std::ptrdiff_t row_pitch,
     std::int32_t width,
     std::int32_t height,
-    float amount,
-    std::uint8_t black_threshold)
+    float amount)
 {
     if (!data || width <= 0 || height <= 0) {
         return;
@@ -141,7 +138,6 @@ void apply_sharpness_3x3(
 
             PixelT& dst = row[x];
             apply_sharpness_rgb(amount,
-                                black_threshold,
                                 blurred_r, blurred_g, blurred_b,
                                 dst.red, dst.green, dst.blue);
         }


### PR DESCRIPTION
## Summary
- apply the sharpening pass globally instead of limiting it to dark areas so it matches Lumetri-style unsharp masking
- remove the black-threshold sharpening parameter and UI from the AE/Premiere plugin
- simplify CLI preprocessing options to use only the sharpening amount

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693308cb62048324b0cb641d91b0fa31)