### PR TITLE
Adjust SC5 messaging in CLI and basic viewer docs

### DIFF
--- a/docs/CLI_guide_en.md
+++ b/docs/CLI_guide_en.md
@@ -52,6 +52,7 @@ The compiled binary will be placed at `platform\\Win\\x64\\msx1pq_cli.exe`.
 | `--help-ja`, `--help-en` | Force Japanese or English help text. |
 
 Notes:
+- SCREEN5 (`--out-sc5`) output is slated for deprecation.
 - `--out-sc2` and `--out-sc5` cannot be used together. When either is specified the output extension changes to `.sc2` or `.sc5` respectively.
 - SCREEN2 export needs the 8-dot/2-color processing enabled (any `--8dot` value other than `none`).
 

--- a/docs/CLI_guide_ja.md
+++ b/docs/CLI_guide_ja.md
@@ -52,6 +52,7 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 | `--help-ja`, `--help-en` | 日本語または英語のヘルプを強制表示。 |
 
 補足:
+- SCREEN5（`--out-sc5`）出力は廃止予定です。
 - `--out-sc2` と `--out-sc5` は同時に指定できません。指定した場合、出力拡張子はそれぞれ `.sc2` / `.sc5` に変わります。
 - SCREEN2 での出力には 8dot 2色処理が必須です（`--8dot none` 以外の指定が必要）。
 

--- a/pyutils/basic_sc2_viewer/README.md
+++ b/pyutils/basic_sc2_viewer/README.md
@@ -3,10 +3,14 @@
 The image (sc2 file) provided as an argument is stored in a disk image and can be displayed using an auto-start BASIC program.
 The disk image can be opened with an emulator. To write it to a 2DD disk, additional tools are required.
 
+Note: SCREEN5 output is planned for deprecation. Future builds are expected to support SCREEN4 instead.
+
 ---
  
 引数で与えられた画像（sc2ファイル）をdiskイメージに格納し、自動起動するBASICプログラムで画像を表示できるようにします。
 diskイメージはエミュレータで開くことができます。実際に2DDディスクに書き込むには、別途ツールが必要です。
+
+注記: 現在はSCREEN5出力にも対応していますが、これは廃止予定です。今後は SCREEN4 対応の追加を予定しています。
 
 
 usage:

--- a/pyutils/basic_sc2_viewer/src/basic_sc2_viewer.py
+++ b/pyutils/basic_sc2_viewer/src/basic_sc2_viewer.py
@@ -6,6 +6,8 @@ from typing import List, Set
 import tempfile
 import msxdisk
 
+# NOTE: SCREEN5 対応は廃止予定で、今後は SCREEN4 対応を追加する予定です。
+
 autoexec_bas = """10 RUN "V.BAS"
 """
 
@@ -113,7 +115,10 @@ def get_file_list(input_paths: List[str], target_exts: Set[str]) -> List[Path]:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Create a MSX disk image with sc2/sc5 viewer.")
+        description=(
+            "Create a MSX disk image with sc2/sc5 viewer. "
+            "SCREEN5 support is slated for removal; SCREEN4 support is planned."
+        ))
     parser.add_argument(
         "input_files_or_dirs",
         nargs="+",
@@ -139,7 +144,7 @@ def main():
     input_paths = args.input_files_or_dirs
     flatten_paths = get_file_list(input_paths, target_exts={'sc2', 'sc5'})
     if not flatten_paths:
-        sys.exit("No .sc2 files found in the provided paths.")
+        sys.exit("No .sc2 or .sc5 files found in the provided paths.")
 
     temp_dir = tempfile.TemporaryDirectory()
     for i, p in enumerate(flatten_paths):

--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -26,6 +26,7 @@ struct CliOptions {
     bool force{false};
 
     int color_system{MSX1PQCore::MSX1PQ_COLOR_SYS_MSX1};
+    // SCREEN5 export is slated for deprecation.
     bool out_sc5{false};
     bool out_sc2{false};
     bool use_dither{true};
@@ -103,6 +104,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
         std::cout << "MMSXX - MSX1 Palette Quantizer\n"
                   << "使い方: " << prog << " --input <ファイル|ディレクトリ> --output <ディレクトリ> [オプション]\n"
                   << "1つの画像またはフォルダ内の複数の画像を受け取り、MSX1(TMS9918)の表示ルールに則った画像に変換します。\n"
+                  << "※ SCREEN5(.sc5) 出力は廃止予定です。\n"
                   << "オプション:\n"
                   << "  --input, -i <ファイル|ディレクトリ>  入力PNGファイルまたはディレクトリを指定\n"
                   << "  --output, -o <ディレクトリ>       出力先ディレクトリを指定\n"
@@ -135,7 +137,8 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
     std::cout << "MMSXX - MSX1 Palette Quantizer\n"
               << "Usage: " << prog << " --input <file|dir> --output <dir> [options]\n"
               << "Convert a single image or multiple images in a folder into images that comply with MSX1 (TMS9918) display rules.\n"
-                  << "Options:\n"
+              << "Note: SCREEN5 (.sc5) output is slated for deprecation.\n"
+              << "Options:\n"
                   << "  --input, -i <file|dir>       Specify the input PNG file or directory\n"
                   << "  --output, -o <dir>           Specify the output directory\n"
                   << "  --out-prefix <string>       Prefix to add to output file names\n"

--- a/tools/disit_items/README.txt
+++ b/tools/disit_items/README.txt
@@ -30,6 +30,8 @@ https://github.com/harayoki/MMSXX_MSX1PaletteQuantizer/blob/main/docs/CLI_guide_
 `basic_sc2_viewer.exe` は 複数の画像生データファイルとBASIC製のビューアーを収めたdskイメージを生成するツールです。
 msx1pq_cli.exe が書き出したsc2/sc5ファイルを引数に渡すと、MSXエミュレーター等で実行できるdskイメージを生成します。
 実際の2DDディスクに書き込めば実機でも実行可能と思われますが、動作確認はしていません。
+なお、SC5対応は廃止予定で、今後はSC4対応に変更予定です。
+また、将来的に入力ファイルとしてsc2の代わりにPNG画像を直接受け入れられるようになる予定です。
 使い方は`basic_sc2_viewer.exe -h` でヘルプを参照してください。
 
 # ドキュメント
@@ -63,6 +65,8 @@ Each line in the batch file can also serve as a reference if you want to run the
 
 `basic_sc2_viewer.exe` is a tool that generates a DSK image containing multiple raw image data files and a BASIC viewer.
 By passing the `.sc2`/`.sc5` files output by `msx1pq_cli.exe` as arguments, it creates a DSK image that can be executed on MSX emulators.
+SC5 support is slated for deprecation, with a switch to planned SC4 support.
+There are also plans to allow passing PNG images directly as inputs instead of only `.sc2` files.
 It is assumed that writing the image to an actual 2DD disk will allow it to run on real hardware, but this has not been verified.
 For usage, refer to the help by running `basic_sc2_viewer.exe -h`.
 # Documentation


### PR DESCRIPTION
## Summary
- update CLI help and guides to state SC5 output is being deprecated without implying future SCREEN4 support
- add note that the basic viewer is expected to accept PNG inputs directly in the future

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934edc3033c83249451dec5b1bb033b)