### PR TITLE
Add dual SCREEN2 ROM generator with alternating display

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_sc2_32k_rom.py
+++ b/pyutils/sc2_viewer_rom/src/create_sc2_32k_rom.py
@@ -1,23 +1,28 @@
-"""Create a 32 KiB (non-MegaROM) MSX ROM that shows a SCREEN2 image.
+"""Create a 32 KiB MSX ROM that alternates two SCREEN2 images.
 
-This script takes an `.sc2` file (raw SCREEN2 VRAM dump) and embeds it into a
-simple 32 KiB ROM. On boot the ROM switches to SCREEN2, copies the VRAM data to
-address 0, and halts so the image stays on screen.
+This script takes two `.sc2` files (raw SCREEN2 VRAM dumps), trims the sprite
+regions, and embeds them into a simple 32 KiB ROM. On boot the ROM switches to
+SCREEN2, copies the first image to VRAM, waits for a key press, shows the second
+image, and keeps alternating indefinitely on each key press.
 """
 from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Tuple
 
 ROM_SIZE = 0x8000  # 32 KiB
-VRAM_SIZE = 0x4000  # SCREEN2 VRAM dump size (16 KiB)
-SC2_HEADER_SIZE = 7  # Optional header seen in some .sc2 files
 ROM_BASE = 0x4000
 HEADER_SIGNATURE = b"AB"
+
+IMAGE_LENGTH = 0x3780  # Trimmed SCREEN2 size
+VRAM_SIZE = 0x4000  # Full SCREEN2 VRAM dump size (16 KiB)
+SC2_HEADER_SIZE = 7  # Optional header seen in some .sc2 files
+
 CHGMOD = 0x005F
 CHGCLR = 0x0062
 LDIRVM = 0x005C
+CHGET = 0x009F
 FORCLR = 0xF3E9
 BAKCLR = 0xF3EA
 BDRCLR = 0xF3EB
@@ -29,25 +34,87 @@ def int_from_str(value: str) -> int:
     return int(value, 0)
 
 
-def build_loader(
-    sc2_address: int, image_length: int, background_color: int, border_color: int
-) -> bytes:
-    """Build the Z80 loader that switches to SCREEN2 and copies VRAM data.
+def sc2_to_trimmed(sc2_bytes: bytes) -> bytes:
+    """Trim SCREEN2 data to the preserved regions.
 
-    The loader uses BIOS calls only, so it works on plain MSX1 hardware.
+    The returned data is always 0x3780 bytes consisting of:
+    - 0000h–1AFFh (pattern generator + name table; sprite attributes removed)
+    - 1B80h–37FFh (color table; sprite pattern removed)
+
+    Accepted input sizes:
+    - 0x4000 + 7 : skip the first 7-byte header then trim
+    - 0x4000     : trim directly
+    - 0x3780     : already trimmed
+    Any other size raises ValueError.
     """
 
-    if image_length > VRAM_SIZE:
-        raise ValueError("SC2 data exceeds SCREEN2 VRAM size")
+    length = len(sc2_bytes)
+
+    if length == IMAGE_LENGTH:
+        return sc2_bytes
+
+    if length == VRAM_SIZE + SC2_HEADER_SIZE:
+        sc2_bytes = sc2_bytes[SC2_HEADER_SIZE:]
+        length = len(sc2_bytes)
+
+    if length == VRAM_SIZE:
+        return sc2_bytes[:0x1B00] + sc2_bytes[0x1B80:0x3800]
+
+    raise ValueError(
+        "Invalid SC2 size: expected 0x4000 (+7 header) or 0x3780 bytes"
+    )
+
+
+def build_loader(
+    image0_addr: int,
+    image1_addr: int,
+    image_length: int,
+    background_color: int,
+    border_color: int,
+) -> bytes:
+    """Build the Z80 loader that swaps two SCREEN2 images on key press."""
+
+    if image_length != IMAGE_LENGTH:
+        raise ValueError("image_length must be 0x3780 bytes")
+
+    def copy_image_block(base_addr: int) -> Tuple[int, ...]:
+        return (
+            0x21,
+            base_addr & 0xFF,
+            (base_addr >> 8) & 0xFF,  # LD HL,image_base
+            0x11,
+            0x00,
+            0x00,  # LD DE,0000h
+            0x01,
+            0x00,
+            0x1B,  # LD BC,1B00h
+            0xCD,
+            LDIRVM & 0xFF,
+            (LDIRVM >> 8) & 0xFF,  # CALL LDIRVM
+            0x21,
+            (base_addr + 0x1B00) & 0xFF,
+            ((base_addr + 0x1B00) >> 8) & 0xFF,  # LD HL,image_base+1B00h
+            0x11,
+            0x80,
+            0x1B,  # LD DE,1B80h
+            0x01,
+            0x80,
+            0x1C,  # LD BC,1C80h
+            0xCD,
+            LDIRVM & 0xFF,
+            (LDIRVM >> 8) & 0xFF,  # CALL LDIRVM
+        )
 
     code: Iterable[int] = (
+        # Set SCREEN2
         0x3E,
-        0x02,  # LD A,2          ; SCREEN2
+        0x02,  # LD A,2
         0xCD,
         CHGMOD & 0xFF,
         (CHGMOD >> 8) & 0xFF,  # CALL CHGMOD
+        # Set colors
         0x3E,
-        0x0F,  # LD A,0Fh        ; foreground (white)
+        0x0F,  # LD A,0Fh (white)
         0x32,
         FORCLR & 0xFF,
         (FORCLR >> 8) & 0xFF,  # LD (FORCLR),A
@@ -64,40 +131,32 @@ def build_loader(
         0xCD,
         CHGCLR & 0xFF,
         (CHGCLR >> 8) & 0xFF,  # CALL CHGCLR
-        0x21,
-        sc2_address & 0xFF,
-        (sc2_address >> 8) & 0xFF,  # LD HL,sc2_data
-        0x11,
-        0x00,
-        0x00,  # LD DE,0000h     ; VRAM destination
-        0x01,
-        image_length & 0xFF,
-        (image_length >> 8) & 0xFF,  # LD BC,data_length
+        # Show image0 initially
+        *copy_image_block(image0_addr),
+        # Main loop
         0xCD,
-        LDIRVM & 0xFF,
-        (LDIRVM >> 8) & 0xFF,  # CALL LDIRVM
+        CHGET & 0xFF,
+        (CHGET >> 8) & 0xFF,  # CALL CHGET (wait for key)
+        *copy_image_block(image1_addr),
+        0xCD,
+        CHGET & 0xFF,
+        (CHGET >> 8) & 0xFF,  # CALL CHGET (wait for key)
+        *copy_image_block(image0_addr),
         0x18,
-        0xFE,  # JR $            ; hang to keep the image
+        0xC8,  # JR back to first CHGET
     )
+
     return bytes(code)
 
 
-def sanitize_sc2_data(sc2_bytes: bytes) -> bytes:
-    """Strip optional 7-byte .sc2 header if present and validate size."""
-
-    if len(sc2_bytes) == VRAM_SIZE + SC2_HEADER_SIZE:
-        return sc2_bytes[SC2_HEADER_SIZE:]
-
-    if len(sc2_bytes) > VRAM_SIZE:
-        raise ValueError("SC2 data must be 16 KiB or smaller")
-
-    return sc2_bytes
-
-
 def build_rom(
-    sc2_bytes: bytes, fill_byte: int, background_color: int, border_color: int
+    image0_bytes: bytes,
+    image1_bytes: bytes,
+    fill_byte: int,
+    background_color: int,
+    border_color: int,
 ) -> bytes:
-    """Build a 32 KiB ROM image that displays the provided SC2 data."""
+    """Build a 32 KiB ROM image that alternates two SCREEN2 images."""
 
     if not 0 <= fill_byte <= 0xFF:
         raise ValueError("fill_byte must fit in a byte")
@@ -105,19 +164,26 @@ def build_rom(
         raise ValueError("background_color must be between 0 and 15")
     if not 0 <= border_color <= 0x0F:
         raise ValueError("border_color must be between 0 and 15")
+    if len(image0_bytes) != IMAGE_LENGTH or len(image1_bytes) != IMAGE_LENGTH:
+        raise ValueError("Both images must be exactly 0x3780 bytes after trimming")
 
     rom = bytearray([fill_byte] * ROM_SIZE)
 
     entry_address = ROM_BASE + 0x10
     code_offset = entry_address - ROM_BASE
 
-    # Reserve space for the loader and align SC2 data on a 16-byte boundary.
-    # The header occupies the first 16 bytes, so we start code at 0x4010.
-    loader_placeholder = build_loader(0, 0, background_color, border_color)
-    data_offset = (code_offset + len(loader_placeholder) + 0x0F) & ~0x0F
-    sc2_address = ROM_BASE + data_offset
+    loader_placeholder = build_loader(0, 0, IMAGE_LENGTH, background_color, border_color)
+    image0_offset = (code_offset + len(loader_placeholder) + 0x0F) & ~0x0F
+    image1_offset = (image0_offset + IMAGE_LENGTH + 0x0F) & ~0x0F
 
-    loader = build_loader(sc2_address, len(sc2_bytes), background_color, border_color)
+    image0_addr = ROM_BASE + image0_offset
+    image1_addr = ROM_BASE + image1_offset
+
+    loader = build_loader(image0_addr, image1_addr, IMAGE_LENGTH, background_color, border_color)
+
+    end_of_images = image1_offset + IMAGE_LENGTH
+    if end_of_images > ROM_SIZE:
+        raise ValueError("Images and loader do not fit in 32 KiB ROM")
 
     # Header
     rom[0:2] = HEADER_SIGNATURE
@@ -129,7 +195,8 @@ def build_rom(
 
     # Body
     rom[code_offset : code_offset + len(loader)] = loader
-    rom[data_offset : data_offset + len(sc2_bytes)] = sc2_bytes
+    rom[image0_offset : image0_offset + IMAGE_LENGTH] = image0_bytes
+    rom[image1_offset : image1_offset + IMAGE_LENGTH] = image1_bytes
 
     return bytes(rom)
 
@@ -137,19 +204,25 @@ def build_rom(
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Embed a SCREEN2 (.sc2) file into a 32 KiB non-MegaROM MSX ROM."
+            "Embed two SCREEN2 (.sc2) files into a 32 KiB non-MegaROM MSX ROM "
+            "that alternates the images on key press."
         )
     )
     parser.add_argument(
-        "input",
+        "image0",
         type=Path,
-        help="Path to the source .sc2 file (raw SCREEN2 VRAM dump)",
+        help="Path to the first .sc2 file (displayed first)",
+    )
+    parser.add_argument(
+        "image1",
+        type=Path,
+        help="Path to the second .sc2 file (displayed after key press)",
     )
     parser.add_argument(
         "-o",
         "--output",
         type=Path,
-        help="Output ROM path (defaults to input name with .rom extension)",
+        help="Output ROM path (defaults to image0 name with .rom extension)",
     )
     parser.add_argument(
         "--fill-byte",
@@ -175,18 +248,25 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
 
-    sc2_path = args.input
-    if not sc2_path.is_file():
-        raise SystemExit(f"Input file not found: {sc2_path}")
+    if not args.image0.is_file():
+        raise SystemExit(f"Input file not found: {args.image0}")
+    if not args.image1.is_file():
+        raise SystemExit(f"Input file not found: {args.image1}")
 
-    sc2_bytes = sanitize_sc2_data(sc2_path.read_bytes())
+    image0_bytes = sc2_to_trimmed(args.image0.read_bytes())
+    image1_bytes = sc2_to_trimmed(args.image1.read_bytes())
+
     rom_bytes = build_rom(
-        sc2_bytes, args.fill_byte, args.background_color, args.border_color
+        image0_bytes,
+        image1_bytes,
+        args.fill_byte,
+        args.background_color,
+        args.border_color,
     )
 
     output_path = args.output
     if output_path is None:
-        output_path = sc2_path.with_suffix(".rom")
+        output_path = args.image0.with_suffix(".rom")
 
     output_path.write_bytes(rom_bytes)
     print(f"Wrote {len(rom_bytes)} bytes to {output_path}")


### PR DESCRIPTION
## Summary
- add support for generating a 32KB ROM that alternates between two SCREEN2 images via key input
- trim sprite regions from input .sc2 files to a 0x3780-byte layout and validate inputs
- update loader to copy both images into VRAM in two blocks and loop on CHGET

## Testing
- python -m compileall pyutils/sc2_viewer_rom/src/create_sc2_32k_rom.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693532d940808324b86a7f8203f238ad)