### PR TITLE
Add msxasmhelper Z80 assembly helper package

### DIFF
--- a/pyutils/README.md
+++ b/pyutils/README.md
@@ -7,3 +7,4 @@ This directory hosts Python (3.11 or later) based tools for the project.
 このディレクトリには Python（3.11以降）向けのツールやライブラリコードを配置します。
 
 - `rom_utils/create_sc2_32k_rom.py`: SCREEN2 (`.sc2`) を32KiBロムに封入するユーティリティ（非メガロム）。
+- `msxasmhelper`: Z80命令をPython呼び出しでバイト列に変換する軽量ヘルパー。

--- a/pyutils/README.md
+++ b/pyutils/README.md
@@ -5,6 +5,3 @@ This directory hosts Python (3.11 or later) based tools for the project.
 # パイソンユーティリティ
 
 このディレクトリには Python（3.11以降）向けのツールやライブラリコードを配置します。
-
-- `rom_utils/create_sc2_32k_rom.py`: SCREEN2 (`.sc2`) を32KiBロムに封入するユーティリティ（非メガロム）。
-- `msxasmhelper`: Z80命令をPython呼び出しでバイト列に変換する軽量ヘルパー。

--- a/pyutils/msxasmhelper/README.md
+++ b/pyutils/msxasmhelper/README.md
@@ -1,4 +1,4 @@
-# msxasmhelper
+# msxasmhelper （WIP)
 
 `msxasmhelper` is a tiny utility library that exposes MSX Z80 mnemonics as Python callables. It focuses on the instructions listed in [`techdocs/z80_assembly_byte_map.md`](../../techdocs/z80_assembly_byte_map.md) and returns the corresponding machine bytes so you can quickly build small programs or ROM snippets.
 

--- a/pyutils/msxasmhelper/README.md
+++ b/pyutils/msxasmhelper/README.md
@@ -1,0 +1,42 @@
+# msxasmhelper
+
+`msxasmhelper` is a tiny utility library that exposes MSX Z80 mnemonics as Python callables. It focuses on the instructions listed in [`techdocs/z80_assembly_byte_map.md`](../../techdocs/z80_assembly_byte_map.md) and returns the corresponding machine bytes so you can quickly build small programs or ROM snippets.
+
+## Installation
+
+```
+pip install msxasmhelper
+```
+
+For local development inside this repository:
+
+```
+pip install -e pyutils/msxasmhelper
+```
+
+## Usage
+
+Each supported mnemonic is available as a function that emits the bytes for that instruction. Placeholders such as `n`, `nn`, and `e` become function arguments in the order they appear in the mnemonic.
+
+```python
+from msxasmhelper import LD_A_n, JP_nn, JR_e
+
+LD_A_n(0x55)          # b"\x3E\x55"
+JP_nn(0x1234)         # b"\xC3\x34\x12"
+JR_e(-2)              # b"\x18\xFE"
+```
+
+You can also assemble directly from the mnemonic string when you want explicit control over the placeholder names:
+
+```python
+from msxasmhelper import assemble
+
+assemble("LD HL,nn", nn=0xC000)
+assemble("CALL NZ,nn", nn=0x1234)
+```
+
+## Notes
+
+- Immediate 16-bit values are encoded in little endian order.
+- Relative offsets (`e`) are validated to fit the signed 8-bit range `[-128, 127]`.
+- If a mnemonic has no operands, its callable accepts no arguments and raises a `TypeError` otherwise.

--- a/pyutils/msxasmhelper/pyproject.toml
+++ b/pyutils/msxasmhelper/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["hatchling>=1.18"]
+build-backend = "hatchling.build"
+
+[project]
+name = "msxasmhelper"
+version = "0.1.0"
+description = "Lightweight helper to convert common MSX Z80 mnemonics into machine bytes"
+readme = "README.md"
+authors = [{ name = "MSX Tools" }]
+license = { text = "MIT" }
+requires-python = ">=3.11"
+keywords = ["MSX", "Z80", "assembler", "bytecode"]
+dependencies = []
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.11",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/harayoki/MMSXX_MSX1PaletteQuantizer/pyutils/msxasmhelper"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/msxasmhelper"]

--- a/pyutils/msxasmhelper/src/msxasmhelper/__init__.py
+++ b/pyutils/msxasmhelper/src/msxasmhelper/__init__.py
@@ -1,0 +1,256 @@
+"""Helper functions for assembling common MSX Z80 mnemonics.
+
+The module exposes every mnemonic listed in ``techdocs/z80_assembly_byte_map.md``
+as a dynamically generated callable. Placeholders such as ``n``, ``nn``, and ``e``
+are converted to function arguments in the order they appear in the mnemonic.
+"""
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Sequence
+
+# Instruction specifications based on techdocs/z80_assembly_byte_map.md
+# Placeholders use a leading colon and are later substituted with encoded values.
+_INSTRUCTION_SET: Dict[str, Sequence[str]] = {
+    # Single byte instructions
+    "NOP": ["00"],
+    "HALT": ["76"],
+    "RLCA": ["07"],
+    "RRCA": ["0F"],
+    "RLA": ["17"],
+    "RRA": ["1F"],
+    "DAA": ["27"],
+    "CPL": ["2F"],
+    "SCF": ["37"],
+    "CCF": ["3F"],
+    "EX DE,HL": ["EB"],
+    "DI": ["F3"],
+    "EI": ["FB"],
+    # 8-bit load
+    "LD A,n": ["3E", ":n"],
+    "LD B,n": ["06", ":n"],
+    "LD C,n": ["0E", ":n"],
+    "LD D,n": ["16", ":n"],
+    "LD E,n": ["1E", ":n"],
+    "LD H,n": ["26", ":n"],
+    "LD L,n": ["2E", ":n"],
+    "LD (HL),n": ["36", ":n"],
+    "LD A,(HL)": ["7E"],
+    "LD (HL),A": ["77"],
+    "LD A,(BC)": ["0A"],
+    "LD A,(DE)": ["1A"],
+    "LD (BC),A": ["02"],
+    "LD (DE),A": ["12"],
+    # 16-bit load
+    "LD BC,nn": ["01", ":nn"],
+    "LD DE,nn": ["11", ":nn"],
+    "LD HL,nn": ["21", ":nn"],
+    "LD SP,nn": ["31", ":nn"],
+    "LD HL,(nn)": ["2A", ":nn"],
+    "LD (nn),HL": ["22", ":nn"],
+    "LD SP,HL": ["F9"],
+    "LD HL,SP+e": ["F8", ":e"],
+    "PUSH BC": ["C5"],
+    "PUSH DE": ["D5"],
+    "PUSH HL": ["E5"],
+    "PUSH AF": ["F5"],
+    "POP BC": ["C1"],
+    "POP DE": ["D1"],
+    "POP HL": ["E1"],
+    "POP AF": ["F1"],
+    # Arithmetic immediate
+    "ADD A,n": ["C6", ":n"],
+    "ADC A,n": ["CE", ":n"],
+    "SUB n": ["D6", ":n"],
+    "SBC A,n": ["DE", ":n"],
+    "AND n": ["E6", ":n"],
+    "XOR n": ["EE", ":n"],
+    "OR n": ["F6", ":n"],
+    "CP n": ["FE", ":n"],
+    # 16-bit arithmetic
+    "ADD HL,BC": ["09"],
+    "ADD HL,DE": ["19"],
+    "ADD HL,HL": ["29"],
+    "ADD HL,SP": ["39"],
+    "INC BC": ["03"],
+    "DEC BC": ["0B"],
+    "INC DE": ["13"],
+    "DEC DE": ["1B"],
+    "INC HL": ["23"],
+    "DEC HL": ["2B"],
+    "INC SP": ["33"],
+    "DEC SP": ["3B"],
+    # Branch
+    "DJNZ e": ["10", ":e"],
+    "JR e": ["18", ":e"],
+    "JR NZ,e": ["20", ":e"],
+    "JR Z,e": ["28", ":e"],
+    "JR NC,e": ["30", ":e"],
+    "JR C,e": ["38", ":e"],
+    "JP nn": ["C3", ":nn"],
+    "JP NZ,nn": ["C2", ":nn"],
+    "JP Z,nn": ["CA", ":nn"],
+    "JP NC,nn": ["D2", ":nn"],
+    "JP C,nn": ["DA", ":nn"],
+    "JP PO,nn": ["E2", ":nn"],
+    "JP PE,nn": ["EA", ":nn"],
+    "JP P,nn": ["F2", ":nn"],
+    "JP M,nn": ["FA", ":nn"],
+    "JP (HL)": ["E9"],
+    "CALL nn": ["CD", ":nn"],
+    "CALL NZ,nn": ["C4", ":nn"],
+    "CALL Z,nn": ["CC", ":nn"],
+    "CALL NC,nn": ["D4", ":nn"],
+    "CALL C,nn": ["DC", ":nn"],
+    "CALL PO,nn": ["E4", ":nn"],
+    "CALL PE,nn": ["EC", ":nn"],
+    "CALL P,nn": ["F4", ":nn"],
+    "CALL M,nn": ["FC", ":nn"],
+    "RET": ["C9"],
+    "RET NZ": ["C0"],
+    "RET Z": ["C8"],
+    "RET NC": ["D0"],
+    "RET C": ["D8"],
+    "RET PO": ["E0"],
+    "RET PE": ["E8"],
+    "RET P": ["F0"],
+    "RET M": ["F8"],
+    "RST 00H": ["C7"],
+    "RST 08H": ["CF"],
+    "RST 10H": ["D7"],
+    "RST 18H": ["DF"],
+    "RST 20H": ["E7"],
+    "RST 28H": ["EF"],
+    "RST 30H": ["F7"],
+    "RST 38H": ["FF"],
+    # Bit operations
+    "RL B": ["CB", "10"],
+    "RR B": ["CB", "18"],
+    "SLA B": ["CB", "20"],
+    "SRA B": ["CB", "28"],
+    "SRL B": ["CB", "38"],
+    "BIT 0,B": ["CB", "40"],
+    "BIT 7,A": ["CB", "7F"],
+    "RES 0,(HL)": ["CB", "86"],
+    "SET 7,(HL)": ["CB", "FE"],
+    # Block transfer / compare
+    "LDI": ["ED", "A0"],
+    "LDD": ["ED", "A8"],
+    "LDIR": ["ED", "B0"],
+    "LDDR": ["ED", "B8"],
+    "CPI": ["ED", "A1"],
+    "CPIR": ["ED", "B1"],
+    "CPD": ["ED", "A9"],
+    "CPDR": ["ED", "B9"],
+}
+
+_PLACEHOLDER_ENCODERS = {
+    "n": lambda value: _encode_unsigned(value, 0xFF, "n"),
+    "nn": lambda value: _encode_unsigned(value, 0xFFFF, "nn", width=2),
+    "e": lambda value: _encode_signed_offset(value),
+}
+
+
+def _encode_unsigned(value: int, max_value: int, name: str, width: int = 1) -> List[int]:
+    integer = int(value)
+    if integer < 0 or integer > max_value:
+        raise ValueError(f"Operand '{name}' must be between 0 and {max_value}")
+    bytes_out = []
+    for _ in range(width):
+        bytes_out.append(integer & 0xFF)
+        integer >>= 8
+    return bytes_out
+
+
+def _encode_signed_offset(value: int) -> List[int]:
+    integer = int(value)
+    if integer < -128 or integer > 127:
+        raise ValueError("Operand 'e' must be a signed 8-bit value (-128..127)")
+    return [(integer + 256) % 256]
+
+
+def _placeholders_for(mnemonic: str) -> List[str]:
+    return [token[1:] for token in _INSTRUCTION_SET[mnemonic] if token.startswith(":")]
+
+
+def assemble(mnemonic: str, /, **operands: int) -> bytes:
+    """Assemble a mnemonic into machine bytes.
+
+    Parameters
+    ----------
+    mnemonic:
+        The assembly mnemonic string such as ``"LD A,n"``.
+    operands:
+        Keyword arguments for any placeholders (``n``, ``nn``, or ``e``).
+
+    Returns
+    -------
+    bytes
+        The assembled machine code.
+    """
+
+    if mnemonic not in _INSTRUCTION_SET:
+        raise KeyError(f"Unsupported mnemonic: {mnemonic}")
+
+    spec = _INSTRUCTION_SET[mnemonic]
+    placeholders = _placeholders_for(mnemonic)
+
+    missing = [name for name in placeholders if name not in operands]
+    if missing:
+        raise KeyError(f"Missing operands for mnemonic '{mnemonic}': {', '.join(missing)}")
+
+    unexpected = set(operands) - set(placeholders)
+    if unexpected:
+        raise KeyError(f"Unexpected operands for mnemonic '{mnemonic}': {', '.join(sorted(unexpected))}")
+
+    assembled: List[int] = []
+    for token in spec:
+        if token.startswith(":"):
+            name = token[1:]
+            encoder = _PLACEHOLDER_ENCODERS[name]
+            assembled.extend(encoder(operands[name]))
+        else:
+            assembled.append(int(token, 16))
+
+    return bytes(assembled)
+
+
+def available_mnemonics() -> List[str]:
+    """Return a sorted list of supported mnemonics."""
+
+    return sorted(_INSTRUCTION_SET.keys())
+
+
+def _mnemonic_to_identifier(mnemonic: str) -> str:
+    identifier = "".join(ch if ch.isalnum() else "_" for ch in mnemonic)
+    return identifier.strip("_")
+
+
+_IDENTIFIER_TO_MNEMONIC = {
+    _mnemonic_to_identifier(mnemonic): mnemonic for mnemonic in _INSTRUCTION_SET
+}
+__all__ = ["assemble", "available_mnemonics"] + sorted(_IDENTIFIER_TO_MNEMONIC.keys())
+
+
+def __getattr__(name: str) -> Callable[..., bytes]:
+    if name not in _IDENTIFIER_TO_MNEMONIC:
+        raise AttributeError(name)
+
+    mnemonic = _IDENTIFIER_TO_MNEMONIC[name]
+    placeholder_order = _placeholders_for(mnemonic)
+
+    def assembler(*args: int, **kwargs: int) -> bytes:
+        if args and len(args) > len(placeholder_order):
+            raise TypeError(
+                f"'{name}' accepts at most {len(placeholder_order)} positional operands"
+            )
+
+        merged = dict(zip(placeholder_order, args))
+        merged.update(kwargs)
+        return assemble(mnemonic, **merged)
+
+    assembler.__name__ = name
+    assembler.__doc__ = (
+        f"Assemble '{mnemonic}'.\n"
+        f"Positional arguments map to operands: {', '.join(placeholder_order) if placeholder_order else 'none'}."
+    )
+    return assembler

--- a/pyutils/msxasmhelper/tests/test_msxasmhelper.py
+++ b/pyutils/msxasmhelper/tests/test_msxasmhelper.py
@@ -1,0 +1,32 @@
+import pytest
+
+import msxasmhelper
+
+
+def test_ld_a_n():
+    assert msxasmhelper.LD_A_n(0x55) == bytes([0x3E, 0x55])
+
+
+def test_jp_nn_and_relative():
+    assert msxasmhelper.JP_nn(0x1234) == bytes([0xC3, 0x34, 0x12])
+    assert msxasmhelper.JR_e(-2) == bytes([0x18, 0xFE])
+
+
+def test_assemble_direct_call():
+    assert msxasmhelper.assemble("LD HL,nn", nn=0xC000) == bytes([0x21, 0x00, 0xC0])
+
+
+def test_invalid_signed_offset():
+    with pytest.raises(ValueError):
+        msxasmhelper.JR_e(-129)
+
+
+def test_operand_mismatch():
+    with pytest.raises(KeyError):
+        msxasmhelper.assemble("LD A,n")
+    with pytest.raises(KeyError):
+        msxasmhelper.assemble("LD A,n", n=0x01, extra=1)
+
+
+def test_available_mnemonics_lists_dynamic_one():
+    assert "LD A,n" in msxasmhelper.available_mnemonics()


### PR DESCRIPTION
## Summary
- add a pip-installable `msxasmhelper` package that exposes Z80 mnemonics as Python callables
- document usage and packaging details for the new helper module
- include basic pytest coverage for assembling immediate and relative instructions

## Testing
- PYTHONPATH=pyutils/msxasmhelper/src python -m pytest pyutils/msxasmhelper/tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693537c0459c8324b4fd28e3d08641d5)