### PR TITLE
Add intermediate dither mapping and debug skip option

### DIFF
--- a/pyutils/simple_sc2_converter/src/simple_sc2_converter/cli.py
+++ b/pyutils/simple_sc2_converter/src/simple_sc2_converter/cli.py
@@ -101,6 +101,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Disable palette dithering before 8-dot color reduction",
     )
     parser.add_argument(
+        "--debug-skip-dither-stage",
+        action="store_true",
+        help=(
+            "Debug option: stop after intermediate color mapping and skip the final dithering stage "
+            "(incompatible with SC2->SC4 conversion)"
+        ),
+    )
+    parser.add_argument(
         "--gamma",
         type=float,
         help=(
@@ -246,6 +254,7 @@ def main(argv: list[str] | None = None) -> int:
         options.hue_shift = args.hue_shift
         options.posterize_colors = args.posterize_colors
         options.enable_dither = not args.no_dither
+        options.skip_dither_application = args.debug_skip_dither_stage
 
         if options.eightdot_mode.upper() == "NONE" and args.format != "png":
             raise ConversionError(


### PR DESCRIPTION
## Summary
- add an intermediate color mapping stage using expanded dithering combinations, including 1:1 blends and black-major 3:1 mixes
- introduce a debug option to stop after the pre-dither stage and block SC2-to-SC4 conversions when enabled
- expose the new debug control via the CLI

## Testing
- python -m compileall pyutils/simple_sc2_converter/src/simple_sc2_converter


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935482ffd28832498f259724af1f44c)