### PR TITLE
Remove provider-specific wording from Linux build docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Debug/
 CLI_Release/
 CLI_Debug/
 dist/
+bin/
 *.rc
 *.res
 *.aex

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ Build the project using Visual Studio (Windows).
 
 `MMSXX_MSX1PaletteQuantizer.aex` will be generated in the `platform\Win\x64` folder.
 
+## Build Instructions for CLI on Linux (container-friendly, not yet fully verified)
+
+These steps build only the `msx1pq_cli` tool for environments without the Adobe SDK (e.g., containerized Linux deployments). They were prepared for container environments but have not been fully verified across distributions.
+
+1. Install the basic build toolchain (Ubuntu example):
+   ```bash
+   sudo apt-get update && sudo apt-get install -y build-essential
+   ```
+2. Build the CLI binary with `make`:
+   ```bash
+   make -C platform/Linux
+   ```
+3. The executable will be placed in `bin/msx1pq_cli`.
+
 ## Build Instructions for Xcode (Mac)
 
 *   Set the `AESDK_ROOT` environment variable to the root of your After Effects SDK installation (e.g., `/Applications/Adobe After Effects 2023/Support Files/After Effects SDK`).

--- a/docs/CLI_guide_en.md
+++ b/docs/CLI_guide_en.md
@@ -4,6 +4,8 @@ The CLI tool `msx1pq_cli` converts PNG images into MSX1/2-style graphics that fo
 
 ## Build
 
+### Windows
+
 Build the Visual Studio project with `msbuild`:
 
 ```bash
@@ -11,6 +13,22 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 ```
 
 The compiled binary will be placed at `platform\\Win\\x64\\msx1pq_cli.exe`.
+
+### Linux (container-friendly, not yet fully verified)
+
+Install build tools (for example on Ubuntu-based images):
+
+```bash
+sudo apt-get update && sudo apt-get install -y build-essential
+```
+
+Then build the CLI binary with `make`:
+
+```bash
+make -C platform/Linux
+```
+
+The compiled binary will be placed at `bin/msx1pq_cli`.
 
 ## Usage
 

--- a/docs/CLI_guide_ja.md
+++ b/docs/CLI_guide_ja.md
@@ -4,6 +4,8 @@ CLI ツール `msx1pq_cli` は、PNG 画像を MSX1/2 風の TMS9918 ルール�
 
 ## ビルド方法
 
+### Windows
+
 `msbuild` で Visual Studio プロジェクトをビルドします:
 
 ```bash
@@ -11,6 +13,22 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 ```
 
 ビルド後、実行ファイルは `platform\\Win\\x64\\msx1pq_cli.exe` に生成されます。
+
+### Linux（コンテナ向け・未完全検証）
+
+Ubuntu 系の場合、まずビルドツールをインストールします。
+
+```bash
+sudo apt-get update && sudo apt-get install -y build-essential
+```
+
+その後、`make` で CLI バイナリをビルドします。
+
+```bash
+make -C platform/Linux
+```
+
+ビルド後、実行ファイルは `bin/msx1pq_cli` に生成されます。
 
 ## 使い方
 

--- a/platform/Linux/Makefile
+++ b/platform/Linux/Makefile
@@ -1,0 +1,32 @@
+# Build msx1pq_cli for containerized Linux environments
+
+# Allow overriding compiler and flags from the environment
+CXX ?= g++
+CXXFLAGS ?= -std=c++17 -O2 -Wall -Wextra -pedantic
+LDFLAGS ?=
+
+# Resolve repository root relative to this Makefile
+REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
+SRC_DIR := $(REPO_ROOT)/src
+CLI_DIR := $(SRC_DIR)/cli
+CORE_DIR := $(SRC_DIR)/core
+
+OUT_DIR ?= $(REPO_ROOT)/bin
+TARGET := $(OUT_DIR)/msx1pq_cli
+
+SOURCES := \
+$(CLI_DIR)/msx1pq_cli.cpp \
+$(CLI_DIR)/lodepng.cpp \
+$(CORE_DIR)/MSX1PQCore.cpp \
+$(CORE_DIR)/MSX1PQPalettes.cpp
+
+.PHONY: all clean
+
+all: $(TARGET)
+
+$(TARGET): $(SOURCES)
+	@mkdir -p $(OUT_DIR)
+	$(CXX) $(CXXFLAGS) -I$(SRC_DIR) $(SOURCES) -o $@ $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET)


### PR DESCRIPTION
## Summary
- replace provider-specific mentions in Linux build docs with generic container-friendly wording
- update English and Japanese CLI guides plus Linux Makefile comment to match the generic phrasing

## Testing
- not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935c3850c7483249d5198e3cf8bae4a)