### PR TITLE
Uppercase asmhelper CALL/DB/DW mnemonics

### DIFF
--- a/pyutils/mmsxxasmhelper/examples/msxrom_boot.py
+++ b/pyutils/mmsxxasmhelper/examples/msxrom_boot.py
@@ -46,7 +46,7 @@ def build_example() -> bytes:
     b.label("start")
 
     # ROM HEADER の配置
-    db(b, *DATA8["MSX_ROM_HEADER"])
+    DB(b, *DATA8["MSX_ROM_HEADER"])
 
     # LD A, INIT_VALUE
     LD.A_n8(b, CONST["INIT_VALUE"])
@@ -68,8 +68,8 @@ def build_example() -> bytes:
 
     # --- データ領域 ---
     b.label("table")
-    db(b, 1, 2, 3, 4)
-    dw(b, 0x1234, 0xABCD)
+    DB(b, 1, 2, 3, 4)
+    DW(b, 0x1234, 0xABCD)
 
     # pad_pattern(b, 128, 0x00)  # 128B境界までパディング
 

--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -35,11 +35,11 @@ v0で入っている機能:
 - 命令ラッパ:
   - JP 系: 無条件/条件付き絶対ジャンプ (JP, JP_Z, JP_NZ, JP_NC, JP_C, JP_PO, JP_PE, JP_P, JP_M, JP_mHL)
   - JR 系: 無条件/条件付き相対ジャンプ (JR, JR_Z, JR_NZ, JR_NC, JR_C) および DJNZ
-  - call(b, label): CALL label
+  - CALL(b, label): CALL label
 
 - データ配置:
-  - db(b, *values): 1バイト列を配置
-  - dw(b, *values): 16bit値(リトルエンディアン)を配置
+  - DB(b, *values): 1バイト列を配置
+  - DW(b, *values): 16bit値(リトルエンディアン)を配置
 
 - DEBUGフラグ:
   - DEBUG = True/False
@@ -59,8 +59,8 @@ __all__ = [
     "pad_pattern",
     "JP", "JP_Z", "JP_NZ", "JP_NC", "JP_C", "JP_PO", "JP_PE", "JP_P", "JP_M", "JP_mHL",
     "JR", "JR_NZ", "JR_Z", "JR_NC", "JR_C", "DJNZ",
-    "call", "Func",
-    "db", "dw",
+    "CALL", "Func",
+    "DB", "DW",
     "LD", "INC", "DEC",
     "HALT",
 ]
@@ -227,7 +227,7 @@ def db_const(b: Block, name: str) -> None:
         data = DATA8[name]
     except KeyError as exc:
         raise ValueError(f"unknown byte data name: {name}") from exc
-    db(b, *data)
+    DB(b, *data)
 
 
 def dw_const(b: Block, name: str) -> None:
@@ -238,7 +238,7 @@ def dw_const(b: Block, name: str) -> None:
         data = DATA16[name]
     except KeyError as exc:
         raise ValueError(f"unknown word data name: {name}") from exc
-    dw(b, *data)
+    DW(b, *data)
 
 
 def db_from_bytes(b: Block, data):
@@ -254,12 +254,12 @@ def db_from_bytes(b: Block, data):
     if isinstance(data, str):
         if data not in DATA8:
             raise KeyError(f"db_from_bytes: const '{data}' not found in DATA8")
-        db(b, *DATA8[data])
+        DB(b, *DATA8[data])
         return
 
     # 素のバイト列
     if isinstance(data, (bytes, bytearray)):
-        db(b, *data)
+        DB(b, *data)
         return
 
     # int の並び（list, tuple 等）
@@ -267,7 +267,7 @@ def db_from_bytes(b: Block, data):
         vals = list(data)
         if not all(isinstance(v, int) for v in vals):
             raise TypeError("db_from_bytes: iterable must contain ints")
-        db(b, *vals)
+        DB(b, *vals)
         return
 
     raise TypeError("db_from_bytes: unsupported data type")
@@ -436,7 +436,7 @@ def DJNZ(b: Block, target: str) -> None:
     _jr_rel8(b, 0x10, target)
 
 
-def call(b: Block, target: str) -> None:
+def CALL(b: Block, target: str) -> None:
     """CALL target (絶対コール)。"""
 
     # CALL nn (opcode 0xCD, nn = 16bit)
@@ -485,7 +485,7 @@ class Func:
     def call(self, b: Block) -> None:
         """CALL命令を発行。"""
 
-        call(b, self.name)
+        CALL(b, self.name)
 
 
 # ---------------------------------------------------------------------------
@@ -959,17 +959,17 @@ class DEC:
 
 
 # ---------------------------------------------------------------------------
-# データ配置ヘルパ: db / dw
+# データ配置ヘルパ: DB / DW
 # ---------------------------------------------------------------------------
 
-def db(b: Block, *values: int) -> None:
+def DB(b: Block, *values: int) -> None:
     """1バイト値を順に配置する。"""
 
     for v in values:
         b.emit(v & 0xFF)
 
 
-def dw(b: Block, *values: int) -> None:
+def DW(b: Block, *values: int) -> None:
     """16bit値(リトルエンディアン)を順に配置する。"""
 
     for v in values:

--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from functools import wraps
 from typing import Callable, Concatenate, Literal, ParamSpec, Sequence
 
-from mmsxxasmhelper.core import Block, LD, db, JP, JP_Z
+from mmsxxasmhelper.core import Block, DB, JP, JP_Z, LD
 
 __all__ = [
     "place_msx_rom_header_macro",
@@ -110,7 +110,7 @@ def place_msx_rom_header_macro(b: Block, entry_point: int = 0x4010, *, preserve_
         (entry_point >> 8) & 0xFF,
         *([0x00] * (16 - 4)),
     ]
-    db(b, *header)
+    DB(b, *header)
 
 
 def palette_bytes(r: int, g: int, b: int) -> tuple[int, int]:
@@ -200,7 +200,7 @@ def set_msx2_palette_default_macro(b: Block, *, preserve_regs: Sequence[Register
     # パレットデータ本体（実行されない領域）
     JP(b, "__MSX2_PAL_DATA_END__")  # 直後のデータを実行しないようにスキップ
     b.label("__PALETTE_DATA__")
-    db(b, *_MSX2_PALETTE_BYTES)
+    DB(b, *_MSX2_PALETTE_BYTES)
     b.label("__MSX2_PAL_DATA_END__")
 
 

--- a/pyutils/sc2_viewer_rom/src/make_scroll_32k_rom.py
+++ b/pyutils/sc2_viewer_rom/src/make_scroll_32k_rom.py
@@ -300,7 +300,7 @@ def build_rom(packed_data: bytes) -> bytes:
 
     # ----- VRAM イメージデータ本体 -----
     b.label("PACKED_DATA")
-    db(b, *packed_data)
+    DB(b, *packed_data)
 
     # origin=0x4000 で fixup 解決
     return b.finalize(origin=ROM_BASE)


### PR DESCRIPTION
## Summary
- rename the asmhelper CALL/DB/DW helpers to uppercase and export them accordingly
- update internal helpers, utilities, and examples to use the new mnemonic names

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c9f5e0ad083248c91f6ab6323d0d2)