### PR TITLE
Respect disabled palette colors during quantization

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -818,6 +818,14 @@ Render (
 
     qi.use_dark_dither = (params[MSX1PQ_PARAM_USE_DARK_DITHER]->u.bd.value != 0);
 
+    for (int i = 0; i < MSX1PQ::kNumBasicColors; ++i) {
+        const PF_ParamIndex flag_index = static_cast<PF_ParamIndex>(MSX1PQ_PARAM_COLOR_FLAG_1 + i);
+        if (flag_index < MSX1PQ_PARAM_NUM_PARAMS) {
+            qi.palette_enabled[static_cast<std::size_t>(i)] =
+                (params[flag_index]->u.bd.value != 0);
+        }
+    }
+
     // 画像サイズ（extent_hint ベース）
     const A_long width  = output->extent_hint.right  - output->extent_hint.left;
     const A_long height = output->extent_hint.bottom - output->extent_hint.top;
@@ -1164,6 +1172,16 @@ SmartRender(
                 param) );
         qi.use_dark_dither = (param.u.bd.value != 0);
         ERR( CheckinParam(in_dataP, param) );
+
+        for (int i = 0; i < MSX1PQ::kNumBasicColors; ++i) {
+            const PF_ParamIndex flag_index = static_cast<PF_ParamIndex>(MSX1PQ_PARAM_COLOR_FLAG_1 + i);
+            ERR( CheckoutParam(
+                    in_dataP,
+                    flag_index,
+                    param) );
+            qi.palette_enabled[static_cast<std::size_t>(i)] = (param.u.bd.value != 0);
+            ERR( CheckinParam(in_dataP, param) );
+        }
 
         // --------------------------------------------------------------------
         // スマートレンダー用 ROI 揃え（ディザ使用時のみ 8ドット境界にスナップ）

--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -341,8 +341,8 @@ bool parse_arguments(int argc, char** argv, CliOptions& opts) {
 
     const int enabled_colors = static_cast<int>(std::count(
         opts.palette_enabled.begin(), opts.palette_enabled.end(), true));
-    if (enabled_colors < 2) {
-        throw std::runtime_error("At least two palette colors must remain enabled");
+    if (enabled_colors < 1) {
+        throw std::runtime_error("At least one palette color must remain enabled");
     }
 
     if (opts.out_sc2 &&
@@ -395,6 +395,13 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
     qi.pre_lut         = opts.pre_lut_data.empty() ? nullptr : opts.pre_lut_data.data();
     qi.pre_lut3d       = opts.pre_lut3d_data.empty() ? nullptr : opts.pre_lut3d_data.data();
     qi.pre_lut3d_size  = opts.pre_lut3d_size;
+
+    for (int i = 0; i < MSX1PQ::kNumBasicColors; ++i) {
+        const std::size_t src_idx = static_cast<std::size_t>(i + 1);
+        if (src_idx < opts.palette_enabled.size()) {
+            qi.palette_enabled[static_cast<std::size_t>(i)] = opts.palette_enabled[src_idx];
+        }
+    }
 
     for (unsigned y = 0; y < height; ++y) {
         for (unsigned x = 0; x < width; ++x) {

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -31,6 +32,11 @@ enum MSX1PQ_ColorSystem {
 };
 
 struct QuantInfo {
+    QuantInfo()
+    {
+        palette_enabled.fill(true);
+    }
+
     bool  use_dither{};
     bool  use_palette_color{};
     int   use_8dot2col{};
@@ -48,6 +54,7 @@ struct QuantInfo {
     const std::uint8_t* pre_lut{nullptr};
     const float* pre_lut3d{nullptr};
     int pre_lut3d_size{0};
+    std::array<bool, MSX1PQ::kNumBasicColors> palette_enabled;
 };
 
 bool load_pre_lut(const std::string& path,
@@ -75,14 +82,17 @@ void apply_preprocess(const QuantInfo *qi,
                       std::uint8_t &b8);
 
 int nearest_palette_rgb(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8,
-                        int num_colors);
+                        int num_colors,
+                        const std::array<bool, MSX1PQ::kNumBasicColors>& palette_enabled);
 
 int nearest_palette_hsb(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8,
                         float w_h, float w_s, float w_b,
-                        int num_colors);
+                        int num_colors,
+                        const std::array<bool, MSX1PQ::kNumBasicColors>& palette_enabled);
 
 int nearest_basic_hsb(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8,
-                      float w_h, float w_s, float w_b);
+                      float w_h, float w_s, float w_b,
+                      const std::array<bool, MSX1PQ::kNumBasicColors>& palette_enabled);
 
 const MSX1PQ::QuantColor* get_basic_palette(int color_system);
 

--- a/src/core/MSX1PQPalettes.cpp
+++ b/src/core/MSX1PQPalettes.cpp
@@ -132,7 +132,6 @@ const MSX1PQ::QuantColor MSX1PQ::kBasicColorsMsx2[15] = {
 };
 
 const int MSX1PQ::kNumQuantColors = sizeof(MSX1PQ::kQuantColors) / sizeof(MSX1PQ::kQuantColors[0]);
-const int MSX1PQ::kNumBasicColors = 15;
 const int MSX1PQ::kNumDarkDitherColors  = 6; // palette_low_luminance の個数
 const int MSX1PQ::kFirstDarkDitherIndex = MSX1PQ::kNumQuantColors - MSX1PQ::kNumDarkDitherColors;
 

--- a/src/core/MSX1PQPalettes.h
+++ b/src/core/MSX1PQPalettes.h
@@ -22,7 +22,7 @@ namespace MSX1PQ {
     extern const int        kNumQuantColors;
 
     // 基本15色の数
-    extern const int        kNumBasicColors;
+    inline constexpr int kNumBasicColors = 15;
 
     // パレットごとのディザ割り当て
     extern const DitherPattern kPaletteDither[];

--- a/src/core/MSX1PQPalettes.h
+++ b/src/core/MSX1PQPalettes.h
@@ -21,8 +21,8 @@ namespace MSX1PQ {
     extern const QuantColor kQuantColors[];
     extern const int        kNumQuantColors;
 
-    // 基本15色の数
-    inline constexpr int kNumBasicColors = 15;
+    // 基本15色の数 (C++14 対応のため inline は付けない)
+    constexpr int kNumBasicColors = 15;
 
     // パレットごとのディザ割り当て
     extern const DitherPattern kPaletteDither[];


### PR DESCRIPTION
## Summary
- propagate palette enable flags from the CLI and After Effects UI into the quantization core
- exclude disabled base colors when selecting palette entries or BEST-mode pairs, including single-color and no-color fallbacks
- permit CLI runs with a single enabled color while defaulting to black if no colors reach the core

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d337a615083248d3ebcff1d9451c5)