### PR TITLE
Add RGB weighting controls

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -291,6 +291,48 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     PF_ADD_FLOAT_SLIDERX(
+        "R weight",
+        0,
+        1,
+        0,
+        1,
+        1,
+        2,
+        0,
+        0,
+        MSX1PQ_PARAM_WEIGHT_R
+    );
+
+    AEFX_CLR_STRUCT(def);
+    PF_ADD_FLOAT_SLIDERX(
+        "G weight",
+        0,
+        1,
+        0,
+        1,
+        1,
+        2,
+        0,
+        0,
+        MSX1PQ_PARAM_WEIGHT_G
+    );
+
+    AEFX_CLR_STRUCT(def);
+    PF_ADD_FLOAT_SLIDERX(
+        "B weight (RGB)",
+        0,
+        1,
+        0,
+        1,
+        1,
+        2,
+        0,
+        0,
+        MSX1PQ_PARAM_WEIGHT_B_RGB
+    );
+
+    AEFX_CLR_STRUCT(def);
+    PF_ADD_FLOAT_SLIDERX(
         "Pre 1: Posterize",
         0,
         255,
@@ -806,6 +848,12 @@ Render (
         static_cast<float>(params[MSX1PQ_PARAM_WEIGHT_S]->u.fs_d.value));
     qi.w_b = clamp01f(
         static_cast<float>(params[MSX1PQ_PARAM_WEIGHT_B]->u.fs_d.value));
+    qi.w_r = clamp01f(
+        static_cast<float>(params[MSX1PQ_PARAM_WEIGHT_R]->u.fs_d.value));
+    qi.w_g = clamp01f(
+        static_cast<float>(params[MSX1PQ_PARAM_WEIGHT_G]->u.fs_d.value));
+    qi.w_b_rgb = clamp01f(
+        static_cast<float>(params[MSX1PQ_PARAM_WEIGHT_B_RGB]->u.fs_d.value));
 
     qi.pre_posterize = clamp_value(
         static_cast<int>(params[MSX1PQ_PARAM_PRE_POSTERIZE]->u.fs_d.value + 0.5),
@@ -1125,6 +1173,27 @@ SmartRender(
         qi.w_b = clamp01f(static_cast<float>(param.u.fs_d.value));
         ERR( CheckinParam(in_dataP, param) );
 
+        ERR( CheckoutParam(
+                in_dataP,
+                MSX1PQ_PARAM_WEIGHT_R,
+                param) );
+        qi.w_r = clamp01f(static_cast<float>(param.u.fs_d.value));
+        ERR( CheckinParam(in_dataP, param) );
+
+        ERR( CheckoutParam(
+                in_dataP,
+                MSX1PQ_PARAM_WEIGHT_G,
+                param) );
+        qi.w_g = clamp01f(static_cast<float>(param.u.fs_d.value));
+        ERR( CheckinParam(in_dataP, param) );
+
+        ERR( CheckoutParam(
+                in_dataP,
+                MSX1PQ_PARAM_WEIGHT_B_RGB,
+                param) );
+        qi.w_b_rgb = clamp01f(static_cast<float>(param.u.fs_d.value));
+        ERR( CheckinParam(in_dataP, param) );
+
         // PRE_POSTERIZE
         ERR( CheckoutParam(
                 in_dataP,
@@ -1351,6 +1420,7 @@ UpdateParameterUI(
 
     A_long mode = params[MSX1PQ_PARAM_DISTANCE_MODE]->u.pd.value;
     A_Boolean enable_hsb = (mode == MSX1PQ_DIST_MODE_HSB);
+    A_Boolean enable_rgb = (mode == MSX1PQ_DIST_MODE_RGB);
 
     // MyDebugLog("=== UpdateParameterUI CALLED ===");
     // MyDebugLog("UpdateParameterUI: mode=%ld enable_hsb=%d",
@@ -1389,6 +1459,36 @@ UpdateParameterUI(
     // MyDebugLog("  B ui_flags(new)=0x%08x", tmp.ui_flags);
     paramUtils->PF_UpdateParamUI(in_data->effect_ref,
                                  MSX1PQ_PARAM_WEIGHT_B,
+                                 &tmp);
+
+    // --- R weight ---
+    tmp = *params[MSX1PQ_PARAM_WEIGHT_R];
+    if (enable_rgb)
+        tmp.ui_flags &= ~PF_PUI_DISABLED;
+    else
+        tmp.ui_flags |= PF_PUI_DISABLED;
+    paramUtils->PF_UpdateParamUI(in_data->effect_ref,
+                                 MSX1PQ_PARAM_WEIGHT_R,
+                                 &tmp);
+
+    // --- G weight ---
+    tmp = *params[MSX1PQ_PARAM_WEIGHT_G];
+    if (enable_rgb)
+        tmp.ui_flags &= ~PF_PUI_DISABLED;
+    else
+        tmp.ui_flags |= PF_PUI_DISABLED;
+    paramUtils->PF_UpdateParamUI(in_data->effect_ref,
+                                 MSX1PQ_PARAM_WEIGHT_G,
+                                 &tmp);
+
+    // --- B weight (RGB) ---
+    tmp = *params[MSX1PQ_PARAM_WEIGHT_B_RGB];
+    if (enable_rgb)
+        tmp.ui_flags &= ~PF_PUI_DISABLED;
+    else
+        tmp.ui_flags |= PF_PUI_DISABLED;
+    paramUtils->PF_UpdateParamUI(in_data->effect_ref,
+                                 MSX1PQ_PARAM_WEIGHT_B_RGB,
                                  &tmp);
 
     return err;

--- a/src/ae/MSX1PaletteQuantizer.h
+++ b/src/ae/MSX1PaletteQuantizer.h
@@ -31,6 +31,9 @@ enum MSX1PQ_ParamId {
     MSX1PQ_PARAM_WEIGHT_H,        // H intensity
     MSX1PQ_PARAM_WEIGHT_S,        // S intensity
     MSX1PQ_PARAM_WEIGHT_B,        // B intensity
+    MSX1PQ_PARAM_WEIGHT_R,        // R intensity (RGB mode)
+    MSX1PQ_PARAM_WEIGHT_G,        // G intensity (RGB mode)
+    MSX1PQ_PARAM_WEIGHT_B_RGB,    // B intensity (RGB mode)
 
     MSX1PQ_PARAM_PRE_POSTERIZE,   // Posterize before preprocessing
     MSX1PQ_PARAM_PRE_SAT,         // Saturation boost

--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -40,6 +40,9 @@ struct CliOptions {
     float weight_h{1.0f};
     float weight_s{0.5f};
     float weight_b{0.75f};
+    float weight_r{1.0f};
+    float weight_g{1.0f};
+    float weight_b_rgb{1.0f};
     int pre_posterize{16};
     float pre_sat{0.0f};
     float pre_gamma{1.0f};
@@ -119,6 +122,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
                   << "  --8dot <none|fast|basic|best|best-attr|best-trans> (デフォルト: best)\n"
                   << "  --distance <rgb|hsb>         (デフォルト: hsb)\n"
                   << "  --weight-h <0-1> --weight-s <0-1> --weight-b <0-1>\n"
+                  << "  --weight-rgb-r <0-1> --weight-rgb-g <0-1> --weight-rgb-b <0-1>\n"
                   << "  --pre-posterize <0-255>      前処理でポスタリゼーションを適用 (デフォルト: 16 1以下は処理なし)\n"
                   << "  --pre-sat <0-10>             処理前に彩度を高く補正 (デフォルト: 0.0)\n"
                   << "  --pre-gamma <0-10>           処理前にガンマを適用 (デフォルト: 1.0)\n"
@@ -152,6 +156,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
               << "  --8dot <none|fast|basic|best|best-attr|best-trans> (default: best)\n"
               << "  --distance <rgb|hsb>         (default: hsb)\n"
               << "  --weight-h <0-1> --weight-s <0-1> --weight-b <0-1>\n"
+              << "  --weight-rgb-r <0-1> --weight-rgb-g <0-1> --weight-rgb-b <0-1>\n"
               << "  --pre-posterize <0-255>      Apply posterization before processing (default: 16,  skipped if <= 1)\n"
               << "  --pre-sat <0-10>             Increase saturation before processing (default: 0.0)\n"
               << "  --pre-gamma <0-10>           Apply a gamma curve before processing (default: 1.0)\n"
@@ -304,6 +309,12 @@ bool parse_arguments(int argc, char** argv, CliOptions& opts) {
             opts.weight_s = std::stof(require_value(arg));
         } else if (arg == "--weight-b") {
             opts.weight_b = std::stof(require_value(arg));
+        } else if (arg == "--weight-rgb-r") {
+            opts.weight_r = std::stof(require_value(arg));
+        } else if (arg == "--weight-rgb-g") {
+            opts.weight_g = std::stof(require_value(arg));
+        } else if (arg == "--weight-rgb-b") {
+            opts.weight_b_rgb = std::stof(require_value(arg));
         } else if (arg == "--pre-posterize") {
             opts.pre_posterize = std::stoi(require_value(arg));
         } else if (arg == "--pre-sat") {
@@ -385,6 +396,9 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
     qi.w_h             = MSX1PQCore::clamp01f(opts.weight_h);
     qi.w_s             = MSX1PQCore::clamp01f(opts.weight_s);
     qi.w_b             = MSX1PQCore::clamp01f(opts.weight_b);
+    qi.w_r             = MSX1PQCore::clamp01f(opts.weight_r);
+    qi.w_g             = MSX1PQCore::clamp01f(opts.weight_g);
+    qi.w_b_rgb         = MSX1PQCore::clamp01f(opts.weight_b_rgb);
     qi.pre_posterize   = std::clamp(opts.pre_posterize, 0, 255);
     qi.pre_sat         = opts.pre_sat;
     qi.pre_gamma       = opts.pre_gamma;

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -44,6 +44,9 @@ struct QuantInfo {
     float w_h{};
     float w_s{};
     float w_b{};
+    float w_r{1.0f};
+    float w_g{1.0f};
+    float w_b_rgb{1.0f};
     int   pre_posterize{8};
     float pre_sat{};
     float pre_gamma{};
@@ -82,8 +85,13 @@ void apply_preprocess(const QuantInfo *qi,
                       std::uint8_t &b8);
 
 int nearest_palette_rgb(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8,
+                        float w_r, float w_g, float w_b,
                         int num_colors,
                         const std::array<bool, MSX1PQ::kNumBasicColors>& palette_enabled);
+
+int nearest_basic_rgb(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8,
+                      float w_r, float w_g, float w_b,
+                      const std::array<bool, MSX1PQ::kNumBasicColors>& palette_enabled);
 
 int nearest_palette_hsb(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8,
                         float w_h, float w_s, float w_b,


### PR DESCRIPTION
## Summary
- add per-channel RGB weights to distance calculations alongside existing HSV weighting
- expose RGB weights through CLI flags and After Effects sliders, enabling them only for RGB distance mode
- allow HSV/RGB weight options to coexist without validation conflicts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d84ec9eac8324b118680d0a4104f2)