### PR TITLE
Add Drawbot swatches for palette color flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ __pycache__/
 *.pyc
 *.pyo
 
+_sdk_temp_/
 tests/msx1pq_outputs/
 tests/msx1pq_autogen_input.png
+
 

--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -585,7 +585,14 @@ static PF_Err DrawPaletteColorBox(
     PF_LayerDef* output,
     void* extra)
 {
+
     PF_EventExtra* ev = reinterpret_cast<PF_EventExtra*>(extra);
+
+    MyDebugLog("EVENT: e_type=%d, appl_id=0x%08X, index=%ld",
+           (int)ev->e_type,
+           (unsigned int)in_data->appl_id,
+           (long)ev->effect_win.index);
+
     if (!ev || ev->e_type != PF_Event_DRAW) {
         return PF_Err_NONE;
     }
@@ -593,7 +600,7 @@ static PF_Err DrawPaletteColorBox(
     (void)out_data;
     (void)output;
 
-    if (in_data->appl_id != 'FXTC') {
+    if (in_data->appl_id == kAppID_Premiere) {
         return PF_Err_NONE;
     }
 

--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -422,6 +422,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*1: Black",
         "Enable",
@@ -432,6 +433,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*2: Medium Green",
         "Enable",
@@ -442,6 +444,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*3: Light Green",
         "Enable",
@@ -452,6 +455,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*4: Dark Blue",
         "Enable",
@@ -462,6 +466,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*5: Light Blue",
         "Enable",
@@ -472,6 +477,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*6: Dark Red",
         "Enable",
@@ -482,6 +488,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*7: Cyan",
         "Enable",
@@ -492,6 +499,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*8: Medium Red",
         "Enable",
@@ -502,6 +510,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*9: Light Red",
         "Enable",
@@ -512,6 +521,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*10: Dark Yellow",
         "Enable",
@@ -522,6 +532,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*11: Light Yellow",
         "Enable",
@@ -532,6 +543,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*12: Dark Green",
         "Enable",
@@ -542,6 +554,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*13: Magenta",
         "Enable",
@@ -552,6 +565,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*14: Gray",
         "Enable",
@@ -562,6 +576,7 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     def.flags |= PF_ParamFlag_SUPERVISE;
+    //def.ui_flags |= PF_PUI_CONTROL  | PF_PUI_DONT_ERASE_CONTROL;
     PF_ADD_CHECKBOX(
         "*15: White",
         "Enable",
@@ -573,7 +588,8 @@ ParamsSetup (
     AEFX_CLR_STRUCT(def);
     PF_END_TOPIC(MSX1PQ_PARAM_TOPIC_PALETTE_CONTROL_END);
 
-    out_data->num_params = MSX1PQ_PARAM_NUM_PARAMS;
+//    out_data->num_params = MSX1PQ_PARAM_NUM_PARAMS;
+    out_data->num_params = MSX1PQ_PARAM_TOPIC_PALETTE_CONTROL_END + 1;
 
     return err;
 }
@@ -588,14 +604,14 @@ static PF_Err DrawPaletteColorBox(
 
     PF_EventExtra* ev = reinterpret_cast<PF_EventExtra*>(extra);
 
+    if (!ev || ev->e_type != PF_Event_DRAW) {
+        return PF_Err_NONE;
+    }
+
     MyDebugLog("EVENT: e_type=%d, appl_id=0x%08X, index=%ld",
            (int)ev->e_type,
            (unsigned int)in_data->appl_id,
            (long)ev->effect_win.index);
-
-    if (!ev || ev->e_type != PF_Event_DRAW) {
-        return PF_Err_NONE;
-    }
 
     (void)out_data;
     (void)output;
@@ -1655,6 +1671,8 @@ EffectMain(
 {
     PF_Err  err = PF_Err_NONE;
 
+//    MyDebugLog("EffectMain: cmd=%d", (int)cmd);
+
     try {
         switch (cmd)
         {
@@ -1702,6 +1720,7 @@ EffectMain(
                           reinterpret_cast<PF_SmartRenderExtra*>(extra));
                 break;
             case PF_Cmd_EVENT:
+                MyDebugLog("############# PF_Cmd_EVENT received");
                 err = DrawPaletteColorBox(in_dataP, out_data, params, output, extra);
                 break;
         }

--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -420,6 +420,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*1: Black",
         "Enable this palette entry",
@@ -429,6 +430,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*2: Medium Green",
         "Enable this palette entry",
@@ -438,6 +440,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*3: Light Green",
         "Enable this palette entry",
@@ -447,6 +450,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*4: Dark Blue",
         "Enable this palette entry",
@@ -456,6 +460,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*5: Light Blue",
         "Enable this palette entry",
@@ -465,6 +470,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*6: Dark Red",
         "Enable this palette entry",
@@ -474,6 +480,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*7: Cyan",
         "Enable this palette entry",
@@ -483,6 +490,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*8: Medium Red",
         "Enable this palette entry",
@@ -492,6 +500,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*9: Light Red",
         "Enable this palette entry",
@@ -501,6 +510,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*10: Dark Yellow",
         "Enable this palette entry",
@@ -510,6 +520,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*11: Light Yellow",
         "Enable this palette entry",
@@ -519,6 +530,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*12: Dark Green",
         "Enable this palette entry",
@@ -528,6 +540,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*13: Magenta",
         "Enable this palette entry",
@@ -537,6 +550,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*14: Gray",
         "Enable this palette entry",
@@ -546,6 +560,7 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    def.flags |= PF_ParamFlag_SUPERVISE;
     PF_ADD_CHECKBOX(
         "*15: White",
         "Enable this palette entry",
@@ -560,6 +575,78 @@ ParamsSetup (
     out_data->num_params = MSX1PQ_PARAM_NUM_PARAMS;
 
     return err;
+}
+
+static PF_Err DrawPaletteColorBox(
+    PF_InData* in_data,
+    PF_OutData* out_data,
+    PF_ParamDef* params[],
+    PF_LayerDef* output,
+    void* extra)
+{
+    PF_EventExtra* ev = reinterpret_cast<PF_EventExtra*>(extra);
+    if (!ev || ev->e_type != PF_Event_DRAW) return PF_Err_NONE;
+
+    (void)out_data;
+    (void)output;
+
+    const PF_ParamIndex p = ev->param_index;
+    if (p < MSX1PQ_PARAM_COLOR_FLAG_1 || p > MSX1PQ_PARAM_COLOR_FLAG_15)
+        return PF_Err_NONE;
+
+    // Premiere 判定。AE 以外は描画しない。
+    if (in_data->appl_id != 'FXTC') {
+        return PF_Err_NONE;
+    }
+
+    // パレット index 0〜14
+    const int idx = static_cast<int>(p - MSX1PQ_PARAM_COLOR_FLAG_1);
+    const MSX1PQ::QuantColor& qc = MSX1PQ::kQuantColors[idx];
+
+    bool enabled = (params[p]->u.bd.value != 0);
+    float alpha  = enabled ? 1.0f : 0.3f;
+
+    // Drawbot セットアップ
+    AEGP_SuiteHandler suites(in_data->pica_basicP);
+    PF_EffectCustomUISuite1* ui_suite = suites.EffectCustomUISuite1();
+    DRAWBOT_DrawRef draw_ref = ui_suite->PF_GetDrawingReference(in_data->effect_ref, ev->contextH);
+    if (!draw_ref) return PF_Err_NONE;
+
+    DRAWBOT_DrawbotSuite1* draw_suite = suites.DrawbotSuite();
+    DRAWBOT_SupplierSuite1* sup_suite = suites.SupplierSuite();
+    DRAWBOT_SurfaceSuite1* surf_suite = suites.SurfaceSuite();
+    DRAWBOT_PathSuite1* path_suite = suites.PathSuite();
+
+    DRAWBOT_SupplierRef supplier = nullptr;
+    DRAWBOT_SurfaceRef surface   = nullptr;
+    draw_suite->GetSupplier(draw_ref, &supplier);
+    draw_suite->GetSurface(draw_ref, &surface);
+
+    (void)sup_suite;
+    (void)path_suite;
+    (void)supplier;
+
+    // 描画矩形の計算
+    PF_Rect r = ev->u.draw.rect;
+    DRAWBOT_RectF32 box;
+    box.left   = static_cast<float>(r.right - 20);
+    box.top    = static_cast<float>(r.top) + 2.0f;
+    box.width  = 16.0f;
+    box.height = static_cast<float>(r.bottom - r.top) - 4.0f;
+
+    // 色
+    DRAWBOT_ColorRGBA col;
+    col.red   = qc.r / 255.0f;
+    col.green = qc.g / 255.0f;
+    col.blue  = qc.b / 255.0f;
+    col.alpha = alpha;
+
+    // BOX をそのまま四角塗りで描く（Path を作らず PaintRect を使う）
+    surf_suite->PushStateStack(surface);
+    surf_suite->PaintRect(surface, &col, &box);
+    surf_suite->PopStateStack(surface);
+
+    return PF_Err_NONE;
 }
 
 
@@ -1553,6 +1640,8 @@ EffectMain(
                           params,
                           reinterpret_cast<PF_SmartRenderExtra*>(extra));
                 break;
+            case PF_Cmd_EVENT:
+                return DrawPaletteColorBox(in_dataP, out_data, params, output, extra);
         }
     } catch(PF_Err &thrown_err) {
         // AE に例外を飛ばさない

--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -154,9 +154,10 @@ GlobalSetup (
     out_data->my_version = MSX1PQ::kVersionPacked;
     // MyDebugLog("my_version = %lu", (unsigned long)out_data->my_version);
 
-        out_data->out_flags  = PF_OutFlag_NONE;
+        out_data->out_flags  = PF_OutFlag_NONE | PF_OutFlag_CUSTOM_UI;
         out_data->out_flags2 = PF_OutFlag2_SUPPORTS_SMART_RENDER |
                                PF_OutFlag2_SUPPORTS_THREADED_RENDERING;
+    //PF_OutFlag_CUSTOM_UI = 0x8000
     //PF_OutFlag2_SUPPORTS_SMART_RENDER = 0x0400
     //PF_OutFlag2_SUPPORTS_THREADED_RENDERING = 0x08000000?
     MyDebugLog("GlobalSetup: out_flags=0x%08X, out_flags2=0x%08X",
@@ -585,74 +586,127 @@ static PF_Err DrawPaletteColorBox(
     void* extra)
 {
     PF_EventExtra* ev = reinterpret_cast<PF_EventExtra*>(extra);
-    if (!ev || ev->e_type != PF_Event_DRAW) return PF_Err_NONE;
+    if (!ev || ev->e_type != PF_Event_DRAW) {
+        return PF_Err_NONE;
+    }
 
     (void)out_data;
     (void)output;
 
-    const PF_ParamIndex p = ev->param_index;
-    if (p < MSX1PQ_PARAM_COLOR_FLAG_1 || p > MSX1PQ_PARAM_COLOR_FLAG_15)
-        return PF_Err_NONE;
-
-    // Premiere 判定。AE 以外は描画しない。
     if (in_data->appl_id != 'FXTC') {
         return PF_Err_NONE;
     }
 
-    // パレット index 0〜14
-    const int idx = static_cast<int>(p - MSX1PQ_PARAM_COLOR_FLAG_1);
-    const MSX1PQ::QuantColor& qc = MSX1PQ::kQuantColors[idx];
+    const PF_EffectWindowInfo& ew = ev->effect_win;
+    const PF_ParamIndex p = static_cast<PF_ParamIndex>(ew.index);
+    if (p < MSX1PQ_PARAM_COLOR_FLAG_1 || p > MSX1PQ_PARAM_COLOR_FLAG_15) {
+        return PF_Err_NONE;
+    }
 
-    bool enabled = (params[p]->u.bd.value != 0);
-    float alpha  = enabled ? 1.0f : 0.3f;
+    PF_Err err = PF_Err_NONE;
 
-    // Drawbot セットアップ
-    AEGP_SuiteHandler suites(in_data->pica_basicP);
-    PF_EffectCustomUISuite1* ui_suite = suites.EffectCustomUISuite1();
-    DRAWBOT_DrawRef draw_ref = ui_suite->PF_GetDrawingReference(in_data->effect_ref, ev->contextH);
-    if (!draw_ref) return PF_Err_NONE;
+    const PF_EffectCustomUISuite1* ui_suite = nullptr;
+    const DRAWBOT_DrawbotSuite1*   draw_suite = nullptr;
+    const DRAWBOT_SupplierSuite1*  sup_suite  = nullptr;
+    const DRAWBOT_SurfaceSuite1*   surf_suite = nullptr;
 
-    DRAWBOT_DrawbotSuite1* draw_suite = suites.DrawbotSuite();
-    DRAWBOT_SupplierSuite1* sup_suite = suites.SupplierSuite();
-    DRAWBOT_SurfaceSuite1* surf_suite = suites.SurfaceSuite();
-    DRAWBOT_PathSuite1* path_suite = suites.PathSuite();
+    err = in_data->pica_basicP->AcquireSuite(
+        kPFEffectCustomUISuite,
+        kPFEffectCustomUISuiteVersion1,
+        reinterpret_cast<const void**>(&ui_suite));
+
+    if (!err) {
+        err = in_data->pica_basicP->AcquireSuite(
+            kDRAWBOT_DrawSuite,
+            kDRAWBOT_DrawSuite_Version1,
+            reinterpret_cast<const void**>(&draw_suite));
+    }
+
+    if (!err) {
+        err = in_data->pica_basicP->AcquireSuite(
+            kDRAWBOT_SupplierSuite,
+            kDRAWBOT_SupplierSuite_Version1,
+            reinterpret_cast<const void**>(&sup_suite));
+    }
+
+    if (!err) {
+        err = in_data->pica_basicP->AcquireSuite(
+            kDRAWBOT_SurfaceSuite,
+            kDRAWBOT_SurfaceSuite_VersionCurrent,
+            reinterpret_cast<const void**>(&surf_suite));
+    }
+
+    DRAWBOT_DrawRef draw_ref = nullptr;
+    if (!err) {
+        err = ui_suite->PF_GetDrawingReference(ev->contextH, &draw_ref);
+        if (!draw_ref && !err) {
+            err = PF_Err_INTERNAL_STRUCT_DAMAGED;
+        }
+    }
 
     DRAWBOT_SupplierRef supplier = nullptr;
-    DRAWBOT_SurfaceRef surface   = nullptr;
-    draw_suite->GetSupplier(draw_ref, &supplier);
-    draw_suite->GetSurface(draw_ref, &surface);
+    DRAWBOT_SurfaceRef  surface  = nullptr;
 
-    (void)sup_suite;
-    (void)path_suite;
-    (void)supplier;
+    if (!err) {
+        err = draw_suite->GetSupplier(draw_ref, &supplier);
+    }
+    if (!err) {
+        err = draw_suite->GetSurface(draw_ref, &surface);
+    }
 
-    // 描画矩形の計算
-    PF_Rect r = ev->u.draw.rect;
-    DRAWBOT_RectF32 box;
-    box.left   = static_cast<float>(r.right - 20);
-    box.top    = static_cast<float>(r.top) + 2.0f;
-    box.width  = 16.0f;
-    box.height = static_cast<float>(r.bottom - r.top) - 4.0f;
+    if (!err && surface) {
+        (void)supplier;
+        const int idx = static_cast<int>(p - MSX1PQ_PARAM_COLOR_FLAG_1);
+        const MSX1PQ::QuantColor& qc = MSX1PQ::kQuantColors[idx];
 
-    // 色
-    DRAWBOT_ColorRGBA col;
-    col.red   = qc.r / 255.0f;
-    col.green = qc.g / 255.0f;
-    col.blue  = qc.b / 255.0f;
-    col.alpha = alpha;
+        const bool enabled = (params[p]->u.bd.value != 0);
 
-    // BOX をそのまま四角塗りで描く（Path を作らず PaintRect を使う）
-    surf_suite->PushStateStack(surface);
-    surf_suite->PaintRect(surface, &col, &box);
-    surf_suite->PopStateStack(surface);
+        const PF_UnionableRect& r = ew.param_title_frame;
+        DRAWBOT_RectF32 box;
+        box.left   = static_cast<float>(r.right - 20);
+        box.top    = static_cast<float>(r.top + 2);
+        box.width  = 16.0f;
+        box.height = static_cast<float>(r.bottom - r.top - 4);
 
-    return PF_Err_NONE;
+        DRAWBOT_ColorRGBA col;
+        col.red   = qc.r / 255.0f;
+        col.green = qc.g / 255.0f;
+        col.blue  = qc.b / 255.0f;
+        col.alpha = enabled ? 1.0f : 0.3f;
+
+        surf_suite->PushStateStack(surface);
+        surf_suite->PaintRect(surface, &col, &box);
+        surf_suite->PopStateStack(surface);
+    }
+
+    if (surf_suite) {
+        in_data->pica_basicP->ReleaseSuite(
+            kDRAWBOT_SurfaceSuite,
+            kDRAWBOT_SurfaceSuite_VersionCurrent);
+    }
+    if (sup_suite) {
+        in_data->pica_basicP->ReleaseSuite(
+            kDRAWBOT_SupplierSuite,
+            kDRAWBOT_SupplierSuite_Version1);
+    }
+    if (draw_suite) {
+        in_data->pica_basicP->ReleaseSuite(
+            kDRAWBOT_DrawSuite,
+            kDRAWBOT_DrawSuite_Version1);
+    }
+    if (ui_suite) {
+        in_data->pica_basicP->ReleaseSuite(
+            kPFEffectCustomUISuite,
+            kPFEffectCustomUISuiteVersion1);
+    }
+
+    return err;
 }
 
 
-// ------------------------------------------------------------
-// 横8ドット内2色制限
-// ------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// 8bit ARGB (AE用) 量子化
+// ---------------------------------------------------------------------------
 
 static void
 apply_8dot2col_dispatch_ARGB(
@@ -1641,7 +1695,8 @@ EffectMain(
                           reinterpret_cast<PF_SmartRenderExtra*>(extra));
                 break;
             case PF_Cmd_EVENT:
-                return DrawPaletteColorBox(in_dataP, out_data, params, output, extra);
+                err = DrawPaletteColorBox(in_dataP, out_data, params, output, extra);
+                break;
         }
     } catch(PF_Err &thrown_err) {
         // AE に例外を飛ばさない

--- a/src/ae/MSX1PaletteQuantizerPiPL.r
+++ b/src/ae/MSX1PaletteQuantizerPiPL.r
@@ -47,7 +47,10 @@ resource 'PiPL' (16000) {
 			0
 		},
 		AE_Effect_Global_OutFlags {
-			PF_OutFlag_NONE
+			0x8000
+			/*
+    			PF_OutFlag_CUSTOM_UI: 0x00000004
+			*/
 		},
         AE_Effect_Global_OutFlags_2 {
             0x08000400

--- a/src/ae/MSX1PaletteQuantizerPiPL.r
+++ b/src/ae/MSX1PaletteQuantizerPiPL.r
@@ -49,7 +49,7 @@ resource 'PiPL' (16000) {
 		AE_Effect_Global_OutFlags {
 			0x8000
 			/*
-    			PF_OutFlag_CUSTOM_UI: 0x00000004
+    			PF_OutFlag_CUSTOM_UI: 0x8000
 			*/
 		},
         AE_Effect_Global_OutFlags_2 {


### PR DESCRIPTION
## Summary
- supervise palette color flag parameters so custom UI drawing is triggered
- add Drawbot-based handler to draw palette color swatches beside the color flag checkboxes in After Effects only
- hook the event command to call the custom drawing routine

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e45aed16c83248cc1c9887c612158)