### PR TITLE
Remove palette control topic from AE UI

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -415,13 +415,6 @@ ParamsSetup (
         MSX1PQ_PARAM_USE_PALETTE_COLOR
     );
 
-    // Palette control topic
-    AEFX_CLR_STRUCT(def);
-    PF_ADD_TOPIC(
-        "MSX1 Palette Control",
-        MSX1PQ_PARAM_TOPIC_PALETTE_CONTROL
-    );
-
     AEFX_CLR_STRUCT(def);
     PF_ADD_CHECKBOX(
         "*1: Black",
@@ -565,9 +558,6 @@ ParamsSetup (
         PF_ParamFlag_SUPERVISE,
         MSX1PQ_PARAM_RANDOMIZE_PALETTE_FLAGS
     );
-
-    AEFX_CLR_STRUCT(def);
-    PF_END_TOPIC(MSX1PQ_PARAM_TOPIC_PALETTE_CONTROL_END);
 
     out_data->num_params = MSX1PQ_PARAM_NUM_PARAMS;
 

--- a/src/ae/MSX1PaletteQuantizer.h
+++ b/src/ae/MSX1PaletteQuantizer.h
@@ -43,7 +43,6 @@ enum MSX1PQ_ParamId {
 
     MSX1PQ_PARAM_USE_PALETTE_COLOR, // Use 92-color palette directly
 
-    MSX1PQ_PARAM_TOPIC_PALETTE_CONTROL, // Topic: palette usage controls
     MSX1PQ_PARAM_COLOR_FLAG_1,          // Checkbox: color 1
     MSX1PQ_PARAM_COLOR_FLAG_2,
     MSX1PQ_PARAM_COLOR_FLAG_3,
@@ -60,7 +59,6 @@ enum MSX1PQ_ParamId {
     MSX1PQ_PARAM_COLOR_FLAG_14,
     MSX1PQ_PARAM_COLOR_FLAG_15,
     MSX1PQ_PARAM_RANDOMIZE_PALETTE_FLAGS, // Button: randomize palette flags
-    MSX1PQ_PARAM_TOPIC_PALETTE_CONTROL_END, // Topic end
 
     MSX1PQ_PARAM_NUM_PARAMS
 };


### PR DESCRIPTION
## Summary
- remove the MSX1 palette control topic grouping so palette checkboxes are not nested
- update parameter IDs accordingly to match the new layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ef0646e208324b5212ef558ee02cc)