### PR TITLE
Clean up Linux build documentation wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Build the project using Visual Studio (Windows).
 
 `MMSXX_MSX1PaletteQuantizer.aex` will be generated in the `platform\Win\x64` folder.
 
-## Build Instructions for CLI on Linux (container-focused, limited verification)
+## Build Instructions for CLI on Linux
 
-These steps build only the `msx1pq_cli` tool for environments without the Adobe SDK (e.g., containerized Linux deployments). They were prepared for container environments but have not been fully verified across distributions.
+These steps build only the `msx1pq_cli` tool for environments without the Adobe SDK.
 
 1. Install the basic build toolchain (Ubuntu example):
    ```bash

--- a/README_ja.md
+++ b/README_ja.md
@@ -80,9 +80,9 @@ platform\Win\x64 フォルダに MMSXX_MSX1PaletteQuantizer.aex が生成され�
 *   `platform/Mac/MSX1PaletteQuantizer.xcodeproj` を Xcode で開きます。
 *   `MSX1PaletteQuantizer` ターゲットをビルドして `MSX1PaletteQuantizer.plugin` を生成します。
 
-## LinuxでのCLIビルド手順（コンテナ向け、検証は限定的）
+## LinuxでのCLIビルド手順
 
-Adobe SDK が不要な環境（例: コンテナ化した Linux 環境）で `msx1pq_cli` のみをビルドする手順です。ディストリビューション全体では未検証です。
+Adobe SDK が不要な環境で `msx1pq_cli` のみをビルドする手順です。
 
 1. ビルド用ツールチェーンをインストール（Ubuntu 例）:
    ```bash

--- a/docs/CLI_guide_en.md
+++ b/docs/CLI_guide_en.md
@@ -14,9 +14,9 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 
 The compiled binary will be placed at `platform\\Win\\x64\\msx1pq_cli.exe`.
 
-### Linux (container-focused, limited verification)
+### Linux
 
-Install build tools (for example on Ubuntu-based images):
+Install build tools (for example on Ubuntu-based systems):
 
 ```bash
 sudo apt-get update && sudo apt-get install -y build-essential

--- a/docs/CLI_guide_ja.md
+++ b/docs/CLI_guide_ja.md
@@ -14,7 +14,7 @@ msbuild platform\\Win\\MSX1PaletteQuantizer_CLI.vcxproj /p:Configuration=Release
 
 ビルド後、実行ファイルは `platform\\Win\\x64\\msx1pq_cli.exe` に生成されます。
 
-### Linux（コンテナ向け、検証は限定的）
+### Linux
 
 Ubuntu 系の場合、まずビルドツールをインストールします。
 


### PR DESCRIPTION
## Summary
- remove container-specific wording from Linux CLI build instructions
- keep Linux build steps while presenting them more generally in both English and Japanese guides

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fe4e9e0148324bc15627305d6d9ce)