### PR TITLE
Include SC2 viewer ROM tool in package

### DIFF
--- a/tools/package_dist.bat
+++ b/tools/package_dist.bat
@@ -8,6 +8,7 @@ set "DIST_DIR=%REPO_ROOT%\dist"
 set "SOURCE_DIR=%REPO_ROOT%\platform\Win\x64"
 set "EXTRA_DIR=%SCRIPT_DIR%disit_items"
 set "BASIC_SC2_VIEWER=%REPO_ROOT%\pyutils\basic_sc2_viewer\dist\basic_sc2_viewer.exe"
+set "SC2_VIEWER_ROM=%REPO_ROOT%\pyutils\sc2_viewer_rom\dist\create_sc2_32k_rom.exe"
 
 if not exist "%DIST_DIR%" (
     echo Creating dist directory: %DIST_DIR%
@@ -32,6 +33,13 @@ if exist "%BASIC_SC2_VIEWER%" (
     copy /Y "%BASIC_SC2_VIEWER%" "%DIST_DIR%" >nul
 ) else (
     echo Basic SC2 Viewer not found: %BASIC_SC2_VIEWER%
+)
+
+echo Copying SC2 Viewer ROM tool from %SC2_VIEWER_ROM% ...
+if exist "%SC2_VIEWER_ROM%" (
+    copy /Y "%SC2_VIEWER_ROM%" "%DIST_DIR%" >nul
+) else (
+    echo SC2 Viewer ROM tool not found: %SC2_VIEWER_ROM%
 )
 
 if exist "%EXTRA_DIR%" (


### PR DESCRIPTION
## Summary
- copy the SC2 Viewer ROM creation tool into the dist folder during packaging
- ensure the executable is included in the generated ZIP archive

## Testing
- not run (batch script change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69406aba820883248a5d0035568111be)