### PR TITLE
Add black-edge sharpening to AE plugin

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <random>
 #include <cstring>
+#include <vector>
 
 
 #ifndef MSX1PQ_IMPL_AEFX_SUITE_HELPER
@@ -172,6 +173,7 @@ namespace MSX1PQ {
 }
 
 using MSX1PQCore::QuantInfo;
+using MSX1PQCore::apply_black_edge_sharpen;
 using MSX1PQCore::apply_preprocess;
 using MSX1PQCore::find_basic_index_from_rgb;
 using MSX1PQCore::get_basic_palette;
@@ -662,6 +664,20 @@ ParamsSetup (
     );
 
     AEFX_CLR_STRUCT(def);
+    PF_ADD_FLOAT_SLIDERX(
+        "Pre 6: Sharpen near black",
+        0,
+        10,
+        0,
+        10,
+        0,
+        2,
+        0,
+        0,
+        MSX1PQ_PARAM_PRE_SHARPEN_BLACK
+    );
+
+    AEFX_CLR_STRUCT(def);
     def.flags    |= PF_ParamFlag_CANNOT_TIME_VARY;
     PF_ADD_CHECKBOX(
         "92-color",
@@ -957,7 +973,59 @@ struct FilterRefcon {
     QuantInfo qi{};
     A_long     global_x0{};
     A_long     global_y0{};
+    const PF_Pixel8* pre_sharpen_argb{nullptr};
+    const MSX1PQ_Pixel_BGRA_8u* pre_sharpen_bgra{nullptr};
+    std::ptrdiff_t pre_sharpen_pitch{0};
 };
+
+template<typename PixelT>
+static void BuildPreSharpenBuffer(
+    const PF_EffectWorld *world,
+    float                 strength,
+    std::vector<PixelT>  &buffer,
+    const PixelT*        &out_ptr,
+    std::ptrdiff_t       &out_pitch)
+{
+    out_ptr = nullptr;
+    out_pitch = 0;
+
+    if (!world || strength <= 0.0f) {
+        return;
+    }
+
+    const A_long width  = world->width;
+    const A_long height = world->height;
+    if (width <= 1 || height <= 1) {
+        return;
+    }
+
+    buffer.resize(static_cast<std::size_t>(width) *
+                  static_cast<std::size_t>(height));
+
+    const std::ptrdiff_t row_bytes = static_cast<std::ptrdiff_t>(world->rowbytes);
+    for (A_long y = 0; y < height; ++y) {
+        const char *row_base = reinterpret_cast<const char*>(world->data);
+        if (row_bytes < 0) {
+            row_base += (world->height - 1 - y) * (-row_bytes);
+        } else {
+            row_base += y * row_bytes;
+        }
+
+        const PixelT *src_row = reinterpret_cast<const PixelT*>(row_base);
+        PixelT *dst_row = buffer.data() + static_cast<std::size_t>(y) * static_cast<std::size_t>(width);
+        std::copy(src_row, src_row + width, dst_row);
+    }
+
+    apply_black_edge_sharpen(
+        buffer.data(),
+        static_cast<std::ptrdiff_t>(width),
+        static_cast<std::int32_t>(width),
+        static_cast<std::int32_t>(height),
+        strength);
+
+    out_ptr   = buffer.data();
+    out_pitch = static_cast<std::ptrdiff_t>(width);
+}
 
 static PF_Err
 FilterImage8 (
@@ -970,10 +1038,17 @@ FilterImage8 (
     auto *ref = reinterpret_cast<FilterRefcon*>(refcon);
     const QuantInfo *qi = &ref->qi;
 
+    const PF_Pixel8 *srcP = inP;
+    if (ref->pre_sharpen_argb) {
+        srcP = ref->pre_sharpen_argb +
+            ref->pre_sharpen_pitch * static_cast<std::ptrdiff_t>(yL) +
+            static_cast<std::ptrdiff_t>(xL);
+    }
+
     // 入力色をローカルコピー
-    A_u_char r = inP->red;
-    A_u_char g = inP->green;
-    A_u_char b = inP->blue;
+    A_u_char r = srcP->red;
+    A_u_char g = srcP->green;
+    A_u_char b = srcP->blue;
 
     // 前処理
     apply_preprocess(qi, r, g, b);
@@ -1011,9 +1086,16 @@ FilterImageBGRA_8u (
     MSX1PQ_Pixel_BGRA_8u *inBGRA_8uP  = reinterpret_cast<MSX1PQ_Pixel_BGRA_8u*>(inP);
     MSX1PQ_Pixel_BGRA_8u *outBGRA_8uP = reinterpret_cast<MSX1PQ_Pixel_BGRA_8u*>(outP);
 
-    A_u_char r = inBGRA_8uP->red;
-    A_u_char g = inBGRA_8uP->green;
-    A_u_char b = inBGRA_8uP->blue;
+    const MSX1PQ_Pixel_BGRA_8u *srcP = inBGRA_8uP;
+    if (ref->pre_sharpen_bgra) {
+        srcP = ref->pre_sharpen_bgra +
+            ref->pre_sharpen_pitch * static_cast<std::ptrdiff_t>(yL) +
+            static_cast<std::ptrdiff_t>(xL);
+    }
+
+    A_u_char r = srcP->red;
+    A_u_char g = srcP->green;
+    A_u_char b = srcP->blue;
 
     apply_preprocess(qi, r, g, b);
 
@@ -1166,6 +1248,10 @@ Render (
     qi.pre_gamma     = static_cast<float>(params[MSX1PQ_PARAM_PRE_GAMMA]->u.fs_d.value);
     qi.pre_contrast  = static_cast<float>(params[MSX1PQ_PARAM_PRE_CONTRAST]->u.fs_d.value);
     qi.pre_hue       = static_cast<float>(params[MSX1PQ_PARAM_PRE_HUE]->u.fs_d.value);
+    qi.pre_sharpen_black = clamp_value(
+        static_cast<float>(params[MSX1PQ_PARAM_PRE_SHARPEN_BLACK]->u.fs_d.value),
+        0.0f,
+        10.0f);
 
     qi.use_dark_dither = (params[MSX1PQ_PARAM_USE_DARK_DITHER]->u.bd.value != 0);
 
@@ -1199,6 +1285,17 @@ Render (
             refcon.qi = qi;
             refcon.global_x0 = output->extent_hint.left;
             refcon.global_y0 = output->extent_hint.top;
+
+            std::vector<MSX1PQ_Pixel_BGRA_8u> sharpen_buffer;
+            if (qi.pre_sharpen_black > 0.0f) {
+                BuildPreSharpenBuffer(
+                    reinterpret_cast<PF_EffectWorld*>(
+                        &params[MSX1PQ_PARAM_INPUT]->u.ld),
+                    qi.pre_sharpen_black,
+                    sharpen_buffer,
+                    refcon.pre_sharpen_bgra,
+                    refcon.pre_sharpen_pitch);
+            }
 
             err = RunIteratePass(
                       in_dataP,
@@ -1236,6 +1333,17 @@ Render (
         refcon.qi = qi;
         refcon.global_x0 = output->extent_hint.left;
         refcon.global_y0 = output->extent_hint.top;
+
+        std::vector<PF_Pixel8> sharpen_buffer;
+        if (qi.pre_sharpen_black > 0.0f) {
+            BuildPreSharpenBuffer(
+                reinterpret_cast<PF_EffectWorld*>(
+                    &params[MSX1PQ_PARAM_INPUT]->u.ld),
+                qi.pre_sharpen_black,
+                sharpen_buffer,
+                refcon.pre_sharpen_argb,
+                refcon.pre_sharpen_pitch);
+        }
 
         err = RunIteratePass(
                   in_dataP,
@@ -1537,6 +1645,16 @@ SmartRender(
         qi.pre_hue = static_cast<float>(param.u.fs_d.value);
         ERR( CheckinParam(in_dataP, param) );
 
+        ERR( CheckoutParam(
+                in_dataP,
+                MSX1PQ_PARAM_PRE_SHARPEN_BLACK,
+                param) );
+        qi.pre_sharpen_black = clamp_value(
+            static_cast<float>(param.u.fs_d.value),
+            0.0f,
+            10.0f);
+        ERR( CheckinParam(in_dataP, param) );
+
         // USE_DARK_DITHER
         ERR( CheckoutParam(
                 in_dataP,
@@ -1639,6 +1757,16 @@ SmartRender(
             refcon.qi = qi;
             refcon.global_x0 = aligned_rect.left;
             refcon.global_y0 = aligned_rect.top;
+
+            std::vector<PF_Pixel8> sharpen_buffer;
+            if (qi.pre_sharpen_black > 0.0f) {
+                BuildPreSharpenBuffer(
+                    &input_roi,
+                    qi.pre_sharpen_black,
+                    sharpen_buffer,
+                    refcon.pre_sharpen_argb,
+                    refcon.pre_sharpen_pitch);
+            }
 
             // ----------------------------------------------------------------
             // 1パス目：通常量子化

--- a/src/ae/MSX1PaletteQuantizer.h
+++ b/src/ae/MSX1PaletteQuantizer.h
@@ -41,6 +41,8 @@ enum MSX1PQ_ParamId {
     MSX1PQ_PARAM_PRE_CONTRAST,    // Contrast correction
     MSX1PQ_PARAM_PRE_HUE,         // Hue rotation
 
+    MSX1PQ_PARAM_PRE_SHARPEN_BLACK, // Sharpen near black areas
+
     MSX1PQ_PARAM_USE_PALETTE_COLOR, // Use 92-color palette directly
 
     MSX1PQ_PARAM_TOPIC_PALETTE_CONTROL, // Topic: palette usage controls

--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -49,6 +49,7 @@ struct CliOptions {
     float pre_gamma{1.0f};
     float pre_contrast{1.0f};
     float pre_hue{0.0f};
+    float pre_sharpen_black{0.0f};
     fs::path pre_lut_path;
     std::vector<std::uint8_t> pre_lut_data;
     std::vector<float> pre_lut3d_data;
@@ -131,6 +132,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
                   << "  --pre-gamma <0-10>           処理前にガンマを適用 (デフォルト: 1.0)\n"
                   << "  --pre-contrast <0-10>        処理前にコントラストを調整 (デフォルト: 1.0)\n"
                   << "  --pre-hue <-180-180>         処理前に色相を変更 (デフォルト: 0.0)\n"
+                  << "  --pre-sharpen-black <0-10>   黒周辺のみシャープ化 (デフォルト: 0.0 おすすめ: 1.0)\n"
                   << "  --disable-colors <番号|範囲>... パレット番号(1-15)を無効化。例: --disable-colors 2 4 7-8 15 (最低2色が必要)\n"
                   << "  --pre-lut <ファイル>           処理前にRGB LUT(256行のRGB値)や.cube 3D LUTを適用\n"
                   << "  --palette92                  (開発用) ディザ処理を行わず92色パレットで出力\n"
@@ -167,6 +169,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
               << "  --pre-gamma <0-10>           Apply a gamma curve before processing (default: 1.0)\n"
               << "  --pre-contrast <0-10>        Adjust contrast before processing (default: 1.0)\n"
               << "  --pre-hue <-180-180>         Adjust hue before processing (default: 0.0)\n"
+              << "  --pre-sharpen-black <0-10>   Sharpen only near black areas before processing (default: 0.0, recommended: 1.0)\n"
               << "  --disable-colors <index|range>... Disable palette indices (1-15). e.g. --disable-colors 2 4 7-8 15. At least two colors must remain enabled\n"
               << "  --pre-lut <file>             Apply RGB LUT (256 rows) or .cube 3D LUT before processing\n"
               << "  -f, --force                  Overwrite without confirmation\n"
@@ -349,6 +352,8 @@ bool parse_arguments(int argc, char** argv, CliOptions& opts) {
             opts.pre_contrast = std::stof(require_value(arg));
         } else if (arg == "--pre-hue") {
             opts.pre_hue = std::stof(require_value(arg));
+        } else if (arg == "--pre-sharpen-black") {
+            opts.pre_sharpen_black = std::stof(require_value(arg));
         } else if (arg == "--pre-lut") {
             opts.pre_lut_path = require_value(arg);
         } else if (arg == "--force" || arg == "-f") {
@@ -433,6 +438,7 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
     qi.pre_gamma       = opts.pre_gamma;
     qi.pre_contrast    = opts.pre_contrast;
     qi.pre_hue         = opts.pre_hue;
+    qi.pre_sharpen_black = MSX1PQCore::clamp_value(opts.pre_sharpen_black, 0.0f, 10.0f);
     qi.use_dark_dither = opts.use_dark_dither;
     qi.color_system    = opts.color_system;
     qi.pre_lut         = opts.pre_lut_data.empty() ? nullptr : opts.pre_lut_data.data();
@@ -444,6 +450,16 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
         if (src_idx < opts.palette_enabled.size()) {
             qi.palette_enabled[static_cast<std::size_t>(i)] = opts.palette_enabled[src_idx];
         }
+    }
+
+    if (opts.use_preprocess && qi.pre_sharpen_black > 0.0f) {
+        const std::ptrdiff_t pitch = static_cast<std::ptrdiff_t>(width);
+        MSX1PQCore::apply_black_edge_sharpen(
+            pixels.data(),
+            pitch,
+            static_cast<std::int32_t>(width),
+            static_cast<std::int32_t>(height),
+            qi.pre_sharpen_black);
     }
 
     for (unsigned y = 0; y < height; ++y) {

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -52,6 +53,7 @@ struct QuantInfo {
     float pre_gamma{};
     float pre_contrast{};
     float pre_hue{};
+    float pre_sharpen_black{};
     bool  use_dark_dither{};
     int   color_system{MSX1PQ_COLOR_SYS_MSX1};
     const std::uint8_t* pre_lut{nullptr};
@@ -83,6 +85,111 @@ void apply_preprocess(const QuantInfo *qi,
                       std::uint8_t &r8,
                       std::uint8_t &g8,
                       std::uint8_t &b8);
+
+template<typename PixelT>
+void apply_black_edge_sharpen(
+    PixelT* data,
+    std::ptrdiff_t row_pitch,
+    std::int32_t   width,
+    std::int32_t   height,
+    float          strength)
+{
+    if (!data || width <= 1 || height <= 1) {
+        return;
+    }
+
+    const float clamped_strength = clamp_value(strength, 0.0f, 10.0f);
+    if (clamped_strength <= 0.0f) {
+        return;
+    }
+
+    const float black_threshold = 0.2f; // 0-1 range
+    const float sharpen_amount  = clamped_strength * 0.2f;
+
+    auto luminance = [](const PixelT& p) {
+        return (0.2126f * static_cast<float>(p.red) +
+                0.7152f * static_cast<float>(p.green) +
+                0.0722f * static_cast<float>(p.blue)) /
+            255.0f;
+    };
+
+    struct BlurSample {
+        float r;
+        float g;
+        float b;
+        float mask;
+    };
+
+    const std::size_t buffer_size = static_cast<std::size_t>(width) *
+                                    static_cast<std::size_t>(height);
+    std::vector<BlurSample> blur_buffer(buffer_size);
+
+    auto clamp_coord = [](int v, int lo, int hi) {
+        return (v < lo) ? lo : (v > hi ? hi : v);
+    };
+
+    for (std::int32_t y = 0; y < height; ++y) {
+        for (std::int32_t x = 0; x < width; ++x) {
+            float sum_r = 0.0f;
+            float sum_g = 0.0f;
+            float sum_b = 0.0f;
+            float min_luma = 1.0f;
+            int count = 0;
+
+            for (int dy = -1; dy <= 1; ++dy) {
+                int sy = clamp_coord(y + dy, 0, height - 1);
+                const PixelT* row = data + static_cast<std::ptrdiff_t>(sy) * row_pitch;
+
+                for (int dx = -1; dx <= 1; ++dx) {
+                    int sx = clamp_coord(x + dx, 0, width - 1);
+                    const PixelT& src = row[sx];
+
+                    sum_r += static_cast<float>(src.red);
+                    sum_g += static_cast<float>(src.green);
+                    sum_b += static_cast<float>(src.blue);
+                    min_luma = std::min(min_luma, luminance(src));
+                    ++count;
+                }
+            }
+
+            const float inv_count = 1.0f / static_cast<float>(count);
+            const float mask = clamp01f((black_threshold - min_luma) / black_threshold);
+
+            const std::size_t idx = static_cast<std::size_t>(y) * static_cast<std::size_t>(width) +
+                                    static_cast<std::size_t>(x);
+            blur_buffer[idx] = {
+                sum_r * inv_count,
+                sum_g * inv_count,
+                sum_b * inv_count,
+                mask,
+            };
+        }
+    }
+
+    auto sharpen_channel = [&](std::uint8_t src, float blurred, float mask) {
+        float high = static_cast<float>(src) - blurred;
+        float adjusted = static_cast<float>(src) + high * sharpen_amount * mask;
+        return static_cast<std::uint8_t>(
+            clamp_value(adjusted + 0.5f, 0.0f, 255.0f));
+    };
+
+    for (std::int32_t y = 0; y < height; ++y) {
+        PixelT* row = data + static_cast<std::ptrdiff_t>(y) * row_pitch;
+        for (std::int32_t x = 0; x < width; ++x) {
+            const std::size_t idx = static_cast<std::size_t>(y) * static_cast<std::size_t>(width) +
+                                    static_cast<std::size_t>(x);
+            const BlurSample& blur = blur_buffer[idx];
+            if (blur.mask <= 0.0f) {
+                continue;
+            }
+
+            PixelT& dst = row[x];
+            dst.red   = sharpen_channel(dst.red,   blur.r, blur.mask);
+            dst.green = sharpen_channel(dst.green, blur.g, blur.mask);
+            dst.blue  = sharpen_channel(dst.blue,  blur.b, blur.mask);
+        }
+    }
+}
 
 int nearest_palette_rgb(std::uint8_t r8, std::uint8_t g8, std::uint8_t b8,
                         float w_r, float w_g, float w_b,


### PR DESCRIPTION
## Summary
- add a black-edge sharpening strength slider to the AE plugin parameters
- propagate the sharpen value into QuantInfo and reuse the core sharpening pass via a preprocessed buffer
- feed sharpened pixels to both standard and smart render pipelines before quantization

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69428490b2008324b72c8119f4deb7b1)