### PR TITLE
Fix palette PNG encoding and include iterator

### DIFF
--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <map>
 #include <optional>
+#include <iterator>
 #include <stdexcept>
 #include <string>
 #include <sstream>
@@ -609,9 +610,16 @@ bool write_palette_png(const fs::path& output_path,
         add_palette_entry(color.r, color.g, color.b, 255);
     }
 
-    const unsigned error = lodepng::encode(output_path.string(), indices, width, height, state);
+    std::vector<unsigned char> png;
+    const unsigned error = lodepng::encode(png, indices, width, height, state);
     if (error) {
         std::cerr << "Failed to write PNG: " << output_path << " (" << lodepng_error_text(error) << ")\n";
+        return false;
+    }
+
+    const unsigned save_error = lodepng::save_file(png, output_path.string());
+    if (save_error) {
+        std::cerr << "Failed to save PNG: " << output_path << " (" << lodepng_error_text(save_error) << ")\n";
         return false;
     }
     return true;


### PR DESCRIPTION
## Summary
- include <iterator> to allow use of std::begin/std::copy_n
- encode palette PNGs using lodepng state output to memory before saving to file

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943843bd9b483249ae24386ff816308)