### PR TITLE
Add black cutoff before black edge sharpening

### DIFF
--- a/src/ae/MSX1PaletteQuantizer.cpp
+++ b/src/ae/MSX1PaletteQuantizer.cpp
@@ -665,7 +665,21 @@ ParamsSetup (
 
     AEFX_CLR_STRUCT(def);
     PF_ADD_FLOAT_SLIDERX(
-        "Pre 6: Sharpen near black",
+        "Pre 6: Black cutoff",
+        0,
+        1,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        MSX1PQ_PARAM_PRE_BLACK_CUTOFF
+    );
+
+    AEFX_CLR_STRUCT(def);
+    PF_ADD_FLOAT_SLIDERX(
+        "Pre 7: Sharpen near black",
         0,
         10,
         0,
@@ -982,6 +996,7 @@ template<typename PixelT>
 static void BuildPreSharpenBuffer(
     const PF_EffectWorld *world,
     float                 strength,
+    float                 black_cutoff,
     std::vector<PixelT>  &buffer,
     const PixelT*        &out_ptr,
     std::ptrdiff_t       &out_pitch)
@@ -989,7 +1004,7 @@ static void BuildPreSharpenBuffer(
     out_ptr = nullptr;
     out_pitch = 0;
 
-    if (!world || strength <= 0.0f) {
+    if (!world || (strength <= 0.0f && black_cutoff <= 0.0f)) {
         return;
     }
 
@@ -1021,7 +1036,8 @@ static void BuildPreSharpenBuffer(
         static_cast<std::ptrdiff_t>(width),
         static_cast<std::int32_t>(width),
         static_cast<std::int32_t>(height),
-        strength);
+        strength,
+        black_cutoff);
 
     out_ptr   = buffer.data();
     out_pitch = static_cast<std::ptrdiff_t>(width);
@@ -1248,6 +1264,8 @@ Render (
     qi.pre_gamma     = static_cast<float>(params[MSX1PQ_PARAM_PRE_GAMMA]->u.fs_d.value);
     qi.pre_contrast  = static_cast<float>(params[MSX1PQ_PARAM_PRE_CONTRAST]->u.fs_d.value);
     qi.pre_hue       = static_cast<float>(params[MSX1PQ_PARAM_PRE_HUE]->u.fs_d.value);
+    qi.pre_black_cutoff = clamp01f(
+        static_cast<float>(params[MSX1PQ_PARAM_PRE_BLACK_CUTOFF]->u.fs_d.value));
     qi.pre_sharpen_black = clamp_value(
         static_cast<float>(params[MSX1PQ_PARAM_PRE_SHARPEN_BLACK]->u.fs_d.value),
         0.0f,
@@ -1287,11 +1305,12 @@ Render (
             refcon.global_y0 = output->extent_hint.top;
 
             std::vector<MSX1PQ_Pixel_BGRA_8u> sharpen_buffer;
-            if (qi.pre_sharpen_black > 0.0f) {
+            if (qi.pre_sharpen_black > 0.0f || qi.pre_black_cutoff > 0.0f) {
                 BuildPreSharpenBuffer(
                     reinterpret_cast<PF_EffectWorld*>(
                         &params[MSX1PQ_PARAM_INPUT]->u.ld),
                     qi.pre_sharpen_black,
+                    qi.pre_black_cutoff,
                     sharpen_buffer,
                     refcon.pre_sharpen_bgra,
                     refcon.pre_sharpen_pitch);
@@ -1335,11 +1354,12 @@ Render (
         refcon.global_y0 = output->extent_hint.top;
 
         std::vector<PF_Pixel8> sharpen_buffer;
-        if (qi.pre_sharpen_black > 0.0f) {
+        if (qi.pre_sharpen_black > 0.0f || qi.pre_black_cutoff > 0.0f) {
             BuildPreSharpenBuffer(
                 reinterpret_cast<PF_EffectWorld*>(
                     &params[MSX1PQ_PARAM_INPUT]->u.ld),
                 qi.pre_sharpen_black,
+                qi.pre_black_cutoff,
                 sharpen_buffer,
                 refcon.pre_sharpen_argb,
                 refcon.pre_sharpen_pitch);
@@ -1647,6 +1667,13 @@ SmartRender(
 
         ERR( CheckoutParam(
                 in_dataP,
+                MSX1PQ_PARAM_PRE_BLACK_CUTOFF,
+                param) );
+        qi.pre_black_cutoff = clamp01f(static_cast<float>(param.u.fs_d.value));
+        ERR( CheckinParam(in_dataP, param) );
+
+        ERR( CheckoutParam(
+                in_dataP,
                 MSX1PQ_PARAM_PRE_SHARPEN_BLACK,
                 param) );
         qi.pre_sharpen_black = clamp_value(
@@ -1759,10 +1786,11 @@ SmartRender(
             refcon.global_y0 = aligned_rect.top;
 
             std::vector<PF_Pixel8> sharpen_buffer;
-            if (qi.pre_sharpen_black > 0.0f) {
+            if (qi.pre_sharpen_black > 0.0f || qi.pre_black_cutoff > 0.0f) {
                 BuildPreSharpenBuffer(
                     &input_roi,
                     qi.pre_sharpen_black,
+                    qi.pre_black_cutoff,
                     sharpen_buffer,
                     refcon.pre_sharpen_argb,
                     refcon.pre_sharpen_pitch);

--- a/src/ae/MSX1PaletteQuantizer.h
+++ b/src/ae/MSX1PaletteQuantizer.h
@@ -41,6 +41,8 @@ enum MSX1PQ_ParamId {
     MSX1PQ_PARAM_PRE_CONTRAST,    // Contrast correction
     MSX1PQ_PARAM_PRE_HUE,         // Hue rotation
 
+    MSX1PQ_PARAM_PRE_BLACK_CUTOFF, // Cut off luminance before black edge sharpen
+
     MSX1PQ_PARAM_PRE_SHARPEN_BLACK, // Sharpen near black areas
 
     MSX1PQ_PARAM_USE_PALETTE_COLOR, // Use 92-color palette directly

--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -51,6 +51,7 @@ struct CliOptions {
     float pre_gamma{1.0f};
     float pre_contrast{1.0f};
     float pre_hue{0.0f};
+    float pre_black_cutoff{0.0f};
     float pre_sharpen_black{0.0f};
     fs::path pre_lut_path;
     std::vector<std::uint8_t> pre_lut_data;
@@ -159,6 +160,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
                   << "  --pre-gamma <0-10>           処理前にガンマを適用 (デフォルト: 1.0)\n"
                   << "  --pre-contrast <0-10>        処理前にコントラストを調整 (デフォルト: 1.0)\n"
                   << "  --pre-hue <-180-180>         処理前に色相を変更 (デフォルト: 0.0)\n"
+                  << "  --pre-black-cutoff <0-1>     黒エッジ強調前に指定輝度未満を黒にする (デフォルト: 0.0)\n"
                   << "  --pre-sharpen-black <0-10>   黒周辺のみシャープ化 (デフォルト: 0.0 おすすめ: 1.0)\n"
                   << "  --disable-colors <番号|範囲>... パレット番号(1-15)を無効化。例: --disable-colors 2 4 7-8 15 (最低2色が必要)\n"
                   << "  --pre-lut <ファイル>           処理前にRGB LUT(256行のRGB値)や.cube 3D LUTを適用\n"
@@ -202,6 +204,7 @@ void print_usage(const char* prog, UsageLanguage lang = UsageLanguage::Japanese)
               << "  --pre-gamma <0-10>           Apply a gamma curve before processing (default: 1.0)\n"
               << "  --pre-contrast <0-10>        Adjust contrast before processing (default: 1.0)\n"
               << "  --pre-hue <-180-180>         Adjust hue before processing (default: 0.0)\n"
+              << "  --pre-black-cutoff <0-1>     Set pixels below this luminance to black before edge enhance (default: 0.0)\n"
               << "  --pre-sharpen-black <0-10>   Sharpen only near black areas before processing (default: 0.0, recommended: 1.0)\n"
               << "  --disable-colors <index|range>... Disable palette indices (1-15). e.g. --disable-colors 2 4 7-8 15. At least two colors must remain enabled\n"
               << "  --pre-lut <file>             Apply RGB LUT (256 rows) or .cube 3D LUT before processing\n"
@@ -405,6 +408,8 @@ bool parse_arguments(int argc, char** argv, CliOptions& opts) {
             opts.pre_contrast = std::stof(require_value(arg));
         } else if (arg == "--pre-hue") {
             opts.pre_hue = std::stof(require_value(arg));
+        } else if (arg == "--pre-black-cutoff") {
+            opts.pre_black_cutoff = std::stof(require_value(arg));
         } else if (arg == "--pre-sharpen-black") {
             opts.pre_sharpen_black = std::stof(require_value(arg));
         } else if (arg == "--pre-lut") {
@@ -682,6 +687,7 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
     qi.pre_gamma       = opts.pre_gamma;
     qi.pre_contrast    = opts.pre_contrast;
     qi.pre_hue         = opts.pre_hue;
+    qi.pre_black_cutoff = MSX1PQCore::clamp_value(opts.pre_black_cutoff, 0.0f, 1.0f);
     qi.pre_sharpen_black = MSX1PQCore::clamp_value(opts.pre_sharpen_black, 0.0f, 10.0f);
     qi.use_dark_dither = opts.use_dark_dither;
     qi.color_system    = opts.color_system;
@@ -703,7 +709,8 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
             pitch,
             static_cast<std::int32_t>(width),
             static_cast<std::int32_t>(height),
-            qi.pre_sharpen_black);
+            qi.pre_sharpen_black,
+            qi.pre_black_cutoff);
     }
 
     for (unsigned y = 0; y < height; ++y) {

--- a/src/core/MSX1PQCore.h
+++ b/src/core/MSX1PQCore.h
@@ -53,6 +53,7 @@ struct QuantInfo {
     float pre_gamma{};
     float pre_contrast{};
     float pre_hue{};
+    float pre_black_cutoff{};
     float pre_sharpen_black{};
     bool  use_dark_dither{};
     int   color_system{MSX1PQ_COLOR_SYS_MSX1};
@@ -92,18 +93,19 @@ void apply_black_edge_sharpen(
     std::ptrdiff_t row_pitch,
     std::int32_t   width,
     std::int32_t   height,
-    float          strength)
+    float          strength,
+    float          black_cutoff)
 {
     if (!data || width <= 1 || height <= 1) {
         return;
     }
 
     const float clamped_strength = clamp_value(strength, 0.0f, 10.0f);
-    if (clamped_strength <= 0.0f) {
+    const float clamped_cutoff   = clamp_value(black_cutoff, 0.0f, 1.0f);
+    if (clamped_strength <= 0.0f && clamped_cutoff <= 0.0f) {
         return;
     }
 
-    const float black_threshold = 0.2f; // 0-1 range
     const float black_detect_threshold = 0.05f; // Detect only near-full black
     const int   spread_radius = 2; // Spread mask 1-2 pixels from black areas
     const float sharpen_amount  = clamped_strength * 0.4f;
@@ -114,6 +116,20 @@ void apply_black_edge_sharpen(
                 0.0722f * static_cast<float>(p.blue)) /
             255.0f;
     };
+
+    if (clamped_cutoff > 0.0f) {
+        for (std::int32_t y = 0; y < height; ++y) {
+            PixelT* row = data + static_cast<std::ptrdiff_t>(y) * row_pitch;
+            for (std::int32_t x = 0; x < width; ++x) {
+                PixelT& p = row[x];
+                if (luminance(p) < clamped_cutoff) {
+                    p.red   = 0;
+                    p.green = 0;
+                    p.blue  = 0;
+                }
+            }
+        }
+    }
 
     struct BlurSample {
         float r;


### PR DESCRIPTION
## Summary
- add configurable black luminance cutoff to preprocessing before black edge sharpening
- expose the cutoff setting through AE parameters and CLI option
- clamp and apply cutoff in core sharpening routine for both AE and CLI pipelines

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69443c2cb654832480dad9b779075be9)