### PR TITLE
Fix palette copy initialization on Windows

### DIFF
--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -791,10 +791,13 @@ std::array<MSX1PQ::QuantColor, MSX1PQ::kNumBasicColors>
 get_basic_palette(int color_system) {
     std::array<MSX1PQ::QuantColor, MSX1PQ::kNumBasicColors> palette{};
 
-    if (color_system == MSX1PQCore::MSX1PQ_COLOR_SYS_MSX2) {
-        std::copy_n(MSX1PQ::kBasicColorsMsx2, MSX1PQ::kNumBasicColors, palette.begin());
-    } else {
-        std::copy_n(MSX1PQ::kQuantColors, MSX1PQ::kNumBasicColors, palette.begin());
+    const auto* source_colors =
+        (color_system == MSX1PQCore::MSX1PQ_COLOR_SYS_MSX2)
+            ? MSX1PQ::kBasicColorsMsx2
+            : MSX1PQ::kQuantColors;
+
+    for (std::size_t i = 0; i < static_cast<std::size_t>(MSX1PQ::kNumBasicColors); ++i) {
+        palette[i] = source_colors[i];
     }
 
     return palette;


### PR DESCRIPTION
## Summary
- replace use of std::copy_n when building the basic palette with a manual copy loop to avoid MSVC overload issues

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69444e7800dc8324a8c4bc23d19a0d0a)