### PR TITLE
Fix PNG IHDR parsing in test helper

### DIFF
--- a/tests/test_msx1pq_cli.py
+++ b/tests/test_msx1pq_cli.py
@@ -25,9 +25,15 @@ def _parse_png_metadata(png_bytes: bytes):
         offset += 12 + length
 
         if chunk_type == b"IHDR":
-            width, height, bit_depth, color_type = struct.unpack(
-                ">IIBB5x", chunk_data + b"\x00" * (13 - len(chunk_data))
-            )
+            (
+                width,
+                height,
+                bit_depth,
+                color_type,
+                _compression,
+                _filter,
+                _interlace,
+            ) = struct.unpack(">IIBBBBB", chunk_data)
         elif chunk_type == b"PLTE":
             if length % 3 != 0:
                 raise ValueError("Invalid PLTE chunk length")


### PR DESCRIPTION
## Summary
- Correct IHDR parsing in the test PNG metadata helper to unpack the standard 13-byte header fields

## Testing
- python -m pytest tests/test_msx1pq_cli.py (skipped on non-Windows)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694452a3343083248a3f153b1f2d0f58)