### PR TITLE
Ensure palette PNGs use 8-bit depth

### DIFF
--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -842,6 +842,7 @@ bool write_palette_png(const fs::path& output_path,
     state.info_raw.bitdepth  = 8;
     state.info_png.color.colortype = LCT_PALETTE;
     state.info_png.color.bitdepth  = 8;
+    state.encoder.auto_convert     = 0; // Preserve explicit 8-bit palette output
 
     const auto add_palette_entry = [&](std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t a) {
         lodepng_palette_add(&state.info_png.color, r, g, b, a);


### PR DESCRIPTION
## Summary
- disable lodepng auto-conversion when writing palette PNGs so the requested 8-bit format is preserved

## Testing
- python -m pytest tests/test_msx1pq_cli.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694454ec115883248fbe4d7678f43ec3)