### PR TITLE
Fix black preprocess controls

### DIFF
--- a/src/cli/msx1pq_cli.cpp
+++ b/src/cli/msx1pq_cli.cpp
@@ -702,7 +702,8 @@ void quantize_image(std::vector<RgbaPixel>& pixels, unsigned width, unsigned hei
         }
     }
 
-    if (opts.use_preprocess && qi.pre_sharpen_black > 0.0f) {
+    if (opts.use_preprocess &&
+        (qi.pre_sharpen_black > 0.0f || qi.pre_black_cutoff > 0.0f)) {
         const std::ptrdiff_t pitch = static_cast<std::ptrdiff_t>(width);
         MSX1PQCore::apply_black_edge_sharpen(
             pixels.data(),

--- a/src/core/MSX1PQCore.cpp
+++ b/src/core/MSX1PQCore.cpp
@@ -327,6 +327,17 @@ void apply_preprocess(const QuantInfo *qi,
 {
     if (!qi) return;
 
+    // Cut off to black before other preprocessing when requested.
+    if (qi->pre_black_cutoff > 0.0f) {
+        const float luma = (0.2126f * static_cast<float>(r8) +
+                            0.7152f * static_cast<float>(g8) +
+                            0.0722f * static_cast<float>(b8)) /
+            255.0f;
+        if (luma < qi->pre_black_cutoff) {
+            r8 = g8 = b8 = 0;
+        }
+    }
+
     if (qi->pre_lut3d && qi->pre_lut3d_size > 1) {
         const int lut_size = qi->pre_lut3d_size;
         const float scale  = static_cast<float>(lut_size - 1);


### PR DESCRIPTION
## Summary
- apply the black cutoff threshold during preprocessing so dark areas drop to black as configured
- run black-edge preprocessing when either sharpen or cutoff is enabled in the CLI pipeline

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69445d4429988324887ff6a972cafaf7)