### PR TITLE
Call ENASLOT after saving stack pointer

### DIFF
--- a/pyutils/mmsxxasmhelper/examples/ascii16_screen8_demo.py
+++ b/pyutils/mmsxxasmhelper/examples/ascii16_screen8_demo.py
@@ -24,6 +24,7 @@ try:
     from mmsxxasmhelper.msxutils import (
         CHGMOD,
         LDIRVM,
+        enaslt_macro,
         place_msx_rom_header_macro,
         store_stack_pointer_macro,
     )
@@ -34,6 +35,7 @@ except ImportError:
     from mmsxxasmhelper.msxutils import (
         CHGMOD,
         LDIRVM,
+        enaslt_macro,
         place_msx_rom_header_macro,
         store_stack_pointer_macro,
     )
@@ -79,6 +81,9 @@ def build_boot_bank() -> bytes:
 
     # ブート直後にスタックポインタを安全な領域へ退避
     store_stack_pointer_macro(b)
+
+    # ENASLOT を呼び出してバンクアクセスを有効化
+    enaslt_macro(b)
 
     # SCREEN 8 初期化
     LD.A_n8(b, 8)


### PR DESCRIPTION
## Summary
- import and invoke ENASLOT macro in the SCREEN 8 ASCII16 demo
- enable bank access right after saving the stack pointer

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694468cfd6ac8324929bbe71773625b5)