### PR TITLE
Fix namespace scoping in MSX1PQCore

### DIFF
--- a/src/core/MSX1PQCore.cpp
+++ b/src/core/MSX1PQCore.cpp
@@ -322,8 +322,6 @@ bool palette_entry_allowed(int palette_idx, int num_colors, const std::array<boo
     return palette_enabled[static_cast<std::size_t>(basic_idx)];
 }
 
-} // namespace
-
 float clamp01f(float v)
 {
     if (v < 0.0f) return 0.0f;


### PR DESCRIPTION
## Summary
- keep helper functions inside the MSX1PQCore namespace by removing an unintended namespace closure

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447115278c832491e0aa1bd42502fb)