### PR TITLE
Add WebAssembly binding scaffold

### DIFF
--- a/src/webasm/MSX1PQWebBindings.cpp
+++ b/src/webasm/MSX1PQWebBindings.cpp
@@ -1,0 +1,190 @@
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#define MSX1PQ_API EMSCRIPTEN_KEEPALIVE
+#else
+#define MSX1PQ_API
+#endif
+
+#include "../core/MSX1PQCore.h"
+#include "../core/MSX1PQOutput.h"
+#include "../core/MSX1PQPalettes.h"
+#include "../core/lodepng.h"
+
+extern "C" {
+
+struct Msx1pqOptions {
+    int color_system;      // MSX1PQCore::MSX1PQ_COLOR_SYS_*
+    int distance_mode;     // MSX1PQCore::MSX1PQ_DIST_MODE_*
+    int eightdot_mode;     // MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_*
+    int use_dither;        // bool
+    int use_palette_color; // bool
+    int use_dark_dither;   // bool
+    float w_h;
+    float w_s;
+    float w_v;
+    float w_r;
+    float w_g;
+    float w_b;
+};
+
+static MSX1PQCore::QuantInfo to_quant_info(const Msx1pqOptions* opts)
+{
+    MSX1PQCore::QuantInfo qi;
+    if (!opts) {
+        qi.use_dither = false;
+        qi.use_palette_color = false;
+        qi.use_8dot2col = MSX1PQCore::MSX1PQ_EIGHTDOT_MODE_NONE;
+        qi.use_hsv = false;
+        qi.use_dark_dither = false;
+        qi.color_system = MSX1PQCore::MSX1PQ_COLOR_SYS_MSX1;
+        qi.w_r = qi.w_g = qi.w_b_rgb = 1.0f;
+        qi.w_h = 1.0f;
+        qi.w_s = 1.0f;
+        qi.w_b = 1.0f;
+        return qi;
+    }
+
+    qi.use_dither = opts->use_dither != 0;
+    qi.use_palette_color = opts->use_palette_color != 0;
+    qi.use_8dot2col = opts->eightdot_mode;
+    qi.use_dark_dither = opts->use_dark_dither != 0;
+    qi.color_system = opts->color_system;
+
+    if (opts->distance_mode == MSX1PQCore::MSX1PQ_DIST_MODE_HSV) {
+        qi.use_hsv = true;
+        qi.w_h = opts->w_h;
+        qi.w_s = opts->w_s;
+        qi.w_b = opts->w_v;
+    } else {
+        qi.use_hsv = false;
+        qi.w_r = opts->w_r;
+        qi.w_g = opts->w_g;
+        qi.w_b_rgb = opts->w_b;
+    }
+
+    return qi;
+}
+
+MSX1PQ_API void* msx1pq_malloc(std::size_t size)
+{
+    return std::malloc(size);
+}
+
+MSX1PQ_API void msx1pq_free(void* ptr)
+{
+    std::free(ptr);
+}
+
+MSX1PQ_API int msx1pq_quantize_rgba(const std::uint8_t* rgba,
+                                    int width,
+                                    int height,
+                                    const Msx1pqOptions* opts,
+                                    std::uint8_t** out_rgba,
+                                    int* out_size)
+{
+    if (!rgba || width <= 0 || height <= 0 || !out_rgba || !out_size) {
+        return -1;
+    }
+
+    const std::size_t pixel_count = static_cast<std::size_t>(width) * static_cast<std::size_t>(height);
+    std::vector<MSX1PQCore::RgbaPixel> pixels(pixel_count);
+
+    for (std::size_t i = 0; i < pixel_count; ++i) {
+        const std::uint8_t* src = rgba + (i * 4);
+        MSX1PQCore::RgbaPixel px{src[0], src[1], src[2], src[3]};
+        pixels[i] = px;
+    }
+
+    const MSX1PQCore::QuantInfo qi = to_quant_info(opts);
+    MSX1PQCore::quantize_image(pixels, static_cast<unsigned>(width), static_cast<unsigned>(height), qi, true);
+
+    *out_size = static_cast<int>(pixel_count * 4);
+    std::uint8_t* buffer = static_cast<std::uint8_t*>(std::malloc(static_cast<std::size_t>(*out_size)));
+    if (!buffer) {
+        return -2;
+    }
+
+    std::memcpy(buffer, pixels.data(), static_cast<std::size_t>(*out_size));
+    *out_rgba = buffer;
+    return 0;
+}
+
+MSX1PQ_API int msx1pq_encode_png(const std::uint8_t* rgba,
+                                 int width,
+                                 int height,
+                                 std::uint8_t** out_png,
+                                 int* out_size)
+{
+    if (!rgba || width <= 0 || height <= 0 || !out_png || !out_size) {
+        return -1;
+    }
+
+    std::vector<unsigned char> png;
+    const unsigned err = lodepng::encode(
+        png,
+        rgba,
+        static_cast<unsigned>(width),
+        static_cast<unsigned>(height),
+        LCT_RGBA,
+        8);
+
+    if (err != 0) {
+        return static_cast<int>(err);
+    }
+
+    *out_size = static_cast<int>(png.size());
+    unsigned char* buffer = static_cast<unsigned char*>(std::malloc(png.size()));
+    if (!buffer) {
+        return -2;
+    }
+
+    std::memcpy(buffer, png.data(), png.size());
+    *out_png = buffer;
+    return 0;
+}
+
+MSX1PQ_API int msx1pq_decode_png(const std::uint8_t* png,
+                                 int size,
+                                 std::uint8_t** out_rgba,
+                                 int* out_width,
+                                 int* out_height)
+{
+    if (!png || size <= 0 || !out_rgba || !out_width || !out_height) {
+        return -1;
+    }
+
+    std::vector<unsigned char> rgba;
+    unsigned w = 0;
+    unsigned h = 0;
+    const unsigned err = lodepng::decode(
+        rgba,
+        w,
+        h,
+        png,
+        static_cast<std::size_t>(size),
+        LCT_RGBA,
+        8);
+
+    if (err != 0) {
+        return static_cast<int>(err);
+    }
+
+    const std::size_t total = rgba.size();
+    unsigned char* buffer = static_cast<unsigned char*>(std::malloc(total));
+    if (!buffer) {
+        return -2;
+    }
+
+    std::memcpy(buffer, rgba.data(), total);
+    *out_rgba = buffer;
+    *out_width = static_cast<int>(w);
+    *out_height = static_cast<int>(h);
+    return 0;
+}
+
+} // extern "C"

--- a/src/webasm/README.md
+++ b/src/webasm/README.md
@@ -1,0 +1,112 @@
+# WebAssembly bindings for MSX1 Palette Quantizer
+
+## 推奨ディレクトリ構成
+```
+src/webasm/
+  CMakeLists.txt        # または build.sh など、Emscripten 用ビルドスクリプト
+  MSX1PQWebBindings.cpp # C API エクスポート実装（emscripten）
+  README.md             # このガイド
+```
+
+## エクスポート API 例（C）
+`MSX1PQWebBindings.cpp` が以下を提供する想定。
+- `msx1pq_malloc` / `msx1pq_free` : JS 側が安全に wasm ヒープを確保・解放するためのラッパー。
+- `msx1pq_quantize_rgba` : RGBA 入力を量子化して RGBA 出力を返す。
+- `msx1pq_encode_png` / `msx1pq_decode_png` : lodepng を使った PNG 変換。
+
+### バインディング実装サンプル
+`MSX1PQWebBindings.cpp` を参照。`extern "C"` + `EMSCRIPTEN_KEEPALIVE` でエクスポートし、`Msx1pqOptions` から `QuantInfo` に変換して `quantize_image` を叩く。
+
+## 初期化と呼び出しの流れ
+1. 必要に応じて `Msx1pqOptions` を JS 側の `HEAP32`/`HEAPF32` に書き込む。
+2. RGBA バッファ（`width * height * 4` バイト）を wasm ヒープにコピー。
+3. `msx1pq_quantize_rgba` を呼ぶと、新しい RGBA バッファへのポインタとサイズが返る。
+4. JS 側で結果を `HEAPU8.subarray(ptr, ptr + size)` で読み出し、終わったら `msx1pq_free` で解放。
+
+### エクスポート関数シグネチャ
+```c
+// ヒープ確保/解放
+void* msx1pq_malloc(size_t size);
+void  msx1pq_free(void* ptr);
+
+// 量子化（RGBA→RGBA）
+int msx1pq_quantize_rgba(const uint8_t* rgba,
+                         int width,
+                         int height,
+                         const Msx1pqOptions* opts,
+                         uint8_t** out_rgba,
+                         int* out_size);
+
+// PNG 変換（任意）
+int msx1pq_encode_png(const uint8_t* rgba, int width, int height,
+                      uint8_t** out_png, int* out_size);
+int msx1pq_decode_png(const uint8_t* png, int size,
+                      uint8_t** out_rgba, int* out_width, int* out_height);
+```
+
+## emcc ビルドコマンド例
+```bash
+emcc -O3 \
+  -std=c++17 \
+  -I./src/core \
+  src/webasm/MSX1PQWebBindings.cpp \
+  src/core/MSX1PQCore.cpp src/core/MSX1PQOutput.cpp src/core/MSX1PQPalettes.cpp src/core/lodepng.cpp \
+  -s ENVIRONMENT=web \
+  -s MODULARIZE=1 -s EXPORT_NAME="MSX1PQ" \
+  -s EXPORTED_FUNCTIONS='["_msx1pq_malloc","_msx1pq_free","_msx1pq_quantize_rgba","_msx1pq_encode_png","_msx1pq_decode_png"]' \
+  -s ALLOW_MEMORY_GROWTH=1 \
+  -s MALLOC="emmalloc" \
+  -o dist/msx1pq.js
+```
+
+## JS からの最小呼び出し例
+```js
+import createMSX1PQ from './msx1pq.js';
+
+const wasm = await createMSX1PQ();
+const { HEAPU8, HEAP32, _msx1pq_malloc, _msx1pq_free, _msx1pq_quantize_rgba } = wasm;
+
+const width = 320, height = 240;
+const inputBytes = new Uint8Array(width * height * 4); // RGBA 入力
+
+// 入力コピー
+const inputPtr = _msx1pq_malloc(inputBytes.length);
+HEAPU8.set(inputBytes, inputPtr);
+
+// オプション配置
+const optsPtr = _msx1pq_malloc(4 * 9); // int*6 + float*3 (簡易例)
+HEAP32[optsPtr >> 2] = 1; // color_system = MSX1
+HEAP32[(optsPtr >> 2) + 1] = 2; // distance_mode = HSV
+HEAP32[(optsPtr >> 2) + 2] = 1; // eightdot_mode = NONE
+HEAP32[(optsPtr >> 2) + 3] = 1; // use_dither
+HEAP32[(optsPtr >> 2) + 4] = 0; // use_palette_color
+HEAP32[(optsPtr >> 2) + 5] = 0; // use_dark_dither
+// floatsは HEAPF32 を使って同じ位置に書き込む
+const f32 = new Float32Array(wasm.HEAPU8.buffer, optsPtr + 24, 3);
+f32[0] = 1.0; // w_h
+f32[1] = 1.0; // w_s
+f32[2] = 1.0; // w_v
+
+// 出力ポインタ用ワーク領域
+const outPtrPtr = _msx1pq_malloc(8); // uint8_t** + int*
+const outSizePtr = outPtrPtr + 4;
+
+const ret = _msx1pq_quantize_rgba(inputPtr, width, height, optsPtr, outPtrPtr, outSizePtr);
+if (ret !== 0) throw new Error(`quantize failed: ${ret}`);
+
+const outPtr = HEAP32[outPtrPtr >> 2];
+const outSize = HEAP32[outSizePtr >> 2];
+const outBytes = HEAPU8.slice(outPtr, outPtr + outSize);
+
+_msx1pq_free(outPtr);
+_msx1pq_free(outPtrPtr);
+_msx1pq_free(optsPtr);
+_msx1pq_free(inputPtr);
+```
+
+## core 側での注意点（Wasm 化）
+- 例外を使わない前提なので `throw` を追加しない。`std::vector` の確保失敗は戻り値で検知して JS にエラーコードを返す。
+- `new/delete` ではなく `malloc/free` を API 経由で隠蔽し、JS 側で解放を徹底する。
+- スレッドやファイル I/O に依存しない（Emscripten の `-s ENVIRONMENT=web` を前提）。
+- 条件付きコンパイルで AE/CLI 依存をビルド対象から除外し、`__EMSCRIPTEN__` 下では Web 固有の設定を追加する程度に留める。
+- `lodepng` はそのままビルド可能。PNG 入出力は wasm 内で完結させ、ブラウザの File API 側とは JS ブリッジでやり取りする。


### PR DESCRIPTION
## Summary
- add initial WebAssembly binding implementation exporting a C API for quantization and PNG helpers
- provide documentation for building with emcc and calling from JavaScript

## Testing
- not run (documentation and scaffolding only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944781f98f48324ac8315dba3429528)