### PR TITLE
Add auto paging defaults and controls to SC2 viewer ROM builder

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -632,9 +632,19 @@ class LD:
         LD.rr(b, "B", "A")
 
     @staticmethod
+    def B_H(b: Block) -> None:
+        """LD B,H"""
+        LD.rr(b, "B", "H")
+
+    @staticmethod
     def C_A(b: Block) -> None:
         """LD C,A"""
         LD.rr(b, "C", "A")
+
+    @staticmethod
+    def C_L(b: Block) -> None:
+        """LD C,L"""
+        LD.rr(b, "C", "L")
 
     @staticmethod
     def D_A(b: Block) -> None:
@@ -647,14 +657,34 @@ class LD:
         LD.rr(b, "D", "B")
 
     @staticmethod
+    def D_H(b: Block) -> None:
+        """LD D,H"""
+        LD.rr(b, "D", "H")
+
+    @staticmethod
     def E_A(b: Block) -> None:
         """LD E,A"""
         LD.rr(b, "E", "A")
 
     @staticmethod
+    def E_L(b: Block) -> None:
+        """LD E,L"""
+        LD.rr(b, "E", "L")
+
+    @staticmethod
     def H_A(b: Block) -> None:
         """LD H,A"""
         LD.rr(b, "H", "A")
+
+    @staticmethod
+    def H_B(b: Block) -> None:
+        """LD H,B"""
+        LD.rr(b, "H", "B")
+
+    @staticmethod
+    def L_C(b: Block) -> None:
+        """LD L,C"""
+        LD.rr(b, "L", "C")
 
 
     # TODO その他 レジスタ間のLDは必要時に増やしていく

--- a/pyutils/sc2_viewer_rom/src/create_sc2_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_sc2_megarom.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 try:
-    from mmsxxasmhelper.core import Block, CALL, CP, DB, DEC, Func, INC, JR, JR_C, JR_NZ, JR_Z, LD, OR, XOR
+    from mmsxxasmhelper.core import ADD, AND, Block, CALL, CP, DB, DEC, Func, INC, JR, JR_C, JR_NZ, JR_Z, LD, OR, XOR
     from mmsxxasmhelper.msxutils import (
         CHGMOD,
         LDIRVM,
@@ -15,10 +15,10 @@ try:
         set_msx2_palette_default_macro,
         store_stack_pointer_macro,
     )
-    from mmsxxasmhelper.utils import pad_bytes
+    from mmsxxasmhelper.utils import JIFFY_ADDR, pad_bytes
 except ImportError:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".." / "mmsxxasmhelper" / "src"))
-    from mmsxxasmhelper.core import Block, CALL, CP, DB, DEC, Func, INC, JR, JR_C, JR_NZ, JR_Z, LD, OR, XOR
+    from mmsxxasmhelper.core import ADD, AND, Block, CALL, CP, DB, DEC, Func, INC, JR, JR_C, JR_NZ, JR_Z, LD, OR, XOR
     from mmsxxasmhelper.msxutils import (
         CHGMOD,
         LDIRVM,
@@ -38,6 +38,10 @@ TRIMMED_SC2_SIZE = 0x3780
 
 ASCII16_PAGE2_REG = 0x7000
 CURRENT_INDEX_ADDR = 0xC000
+AUTO_INTERVAL_ADDR = 0xC001
+AUTO_INTERVAL_PREV_ADDR = 0xC003
+AUTO_COUNTDOWN_ADDR = 0xC005
+LAST_JIFFY_ADDR = 0xC007
 
 CHSNS = 0x009C
 CHGET = 0x009F
@@ -46,17 +50,23 @@ CHGCLR = 0x0062
 FORCLR = 0xF3E9
 BAKCLR = 0xF3EA
 BDRCLR = 0xF3EB
+SNSMAT = 0x0141
 
 KEY_SPACE = 0x20
 KEY_UP = 0x1E
 KEY_DOWN = 0x1F
 KEY_ESC = 0x1B
 
+KEYBOARD_ROW_SHIFT = 0x06
+KEYBOARD_SHIFT_MASK = 0x01
+
 INSTRUCTION_TEXT = (
     "MMSXX SC2 VIEWER\r\n"
     "\r\n"
-    "SPACE/DOWN: NEXT\r\n"
+    "SPACE: NEXT + PAUSE\r\n"
+    "DOWN: NEXT\r\n"
     "UP: PREV\r\n"
+    "SHIFT+UD: SPD\r\n"
     "ESC: FIRST\r\n"
     "\r\n"
     "PRESS ANY KEY\r\n"
@@ -64,9 +74,18 @@ INSTRUCTION_TEXT = (
 
 INSTRUCTION_BG_COLOR = 0x04
 
+JIFFY_PER_SECOND = 60
+
 
 def int_from_str(value: str) -> int:
     return int(value, 0)
+
+
+def seconds_to_jiffies(seconds: float) -> int:
+    if seconds < 0:
+        raise ValueError("Seconds value must be zero or greater")
+    ticks = int(round(seconds * JIFFY_PER_SECOND))
+    return min(ticks, 0xFFFF)
 
 
 def sc2_to_vram(sc2_bytes: bytes) -> bytes:
@@ -96,9 +115,29 @@ def build_boot_bank(
     image_count: int,
     show_instructions: bool,
     background_color: int,
+    auto_interval_ticks: int,
+    auto_step_ticks: int,
+    auto_min_ticks: int,
+    auto_max_ticks: int,
+    auto_resume_ticks: int,
 ) -> bytes:
     if not 1 <= image_count <= 0xFF:
         raise ValueError("image_count must be between 1 and 255")
+    for name, value in {
+        "auto_interval_ticks": auto_interval_ticks,
+        "auto_step_ticks": auto_step_ticks,
+        "auto_min_ticks": auto_min_ticks,
+        "auto_max_ticks": auto_max_ticks,
+        "auto_resume_ticks": auto_resume_ticks,
+    }.items():
+        if not 0 <= value <= 0xFFFF:
+            raise ValueError(f"{name} must fit in 16 bits")
+    if auto_step_ticks <= 0:
+        raise ValueError("auto_step_ticks must be positive")
+    if auto_min_ticks <= 0:
+        raise ValueError("auto_min_ticks must be positive")
+    if auto_min_ticks > auto_max_ticks:
+        raise ValueError("auto_min_ticks must be less than or equal to auto_max_ticks")
 
     b = Block()
     place_msx_rom_header_macro(b, entry_point=0x4010)
@@ -125,6 +164,178 @@ def build_boot_bank(
 
     PRINT_STRING = Func("print_string", print_string)
 
+    def reset_auto_timer(block: Block) -> None:
+        LD.HL_mn16(block, AUTO_INTERVAL_ADDR)
+        LD.mn16_HL(block, AUTO_COUNTDOWN_ADDR)
+        LD.HL_mn16(block, JIFFY_ADDR)
+        LD.mn16_HL(block, LAST_JIFFY_ADDR)
+
+    RESET_AUTO_TIMER = Func("reset_auto_timer", reset_auto_timer)
+
+    def set_auto_interval(block: Block) -> None:
+        LD.mn16_HL(block, AUTO_INTERVAL_ADDR)
+        LD.A_H(block)
+        OR.L(block)
+        JR_Z(block, "set_auto_interval_skip_prev")
+        LD.mn16_HL(block, AUTO_INTERVAL_PREV_ADDR)
+        block.label("set_auto_interval_skip_prev")
+        RESET_AUTO_TIMER.call(block)
+
+    SET_AUTO_INTERVAL = Func("set_auto_interval", set_auto_interval)
+
+    def next_image(block: Block) -> None:
+        LD.A_mn16(block, CURRENT_INDEX_ADDR)
+        INC.A(block)
+        CP.n8(block, image_count)
+        JR_C(block, "store_index_next")
+        XOR.A(block)
+        block.label("store_index_next")
+        LD.mn16_A(block, CURRENT_INDEX_ADDR)
+        LD.rr(block, "C", "A")
+        INC.C(block)
+        LOAD_AND_SHOW.call(block)
+        RESET_AUTO_TIMER.call(block)
+
+    NEXT_IMAGE = Func("next_image", next_image)
+
+    def prev_image(block: Block) -> None:
+        LD.A_mn16(block, CURRENT_INDEX_ADDR)
+        OR.A(block)
+        JR_NZ(block, "dec_index")
+        LD.A_n8(block, (image_count - 1) & 0xFF)
+        JR(block, "store_index_prev")
+        block.label("dec_index")
+        DEC.A(block)
+        block.label("store_index_prev")
+        LD.mn16_A(block, CURRENT_INDEX_ADDR)
+        LD.rr(block, "C", "A")
+        INC.C(block)
+        LOAD_AND_SHOW.call(block)
+        RESET_AUTO_TIMER.call(block)
+
+    PREV_IMAGE = Func("prev_image", prev_image)
+
+    def reset_image(block: Block) -> None:
+        XOR.A(block)
+        LD.mn16_A(block, CURRENT_INDEX_ADDR)
+        LD.C_n8(block, 1)
+        LOAD_AND_SHOW.call(block)
+        RESET_AUTO_TIMER.call(block)
+
+    RESET_IMAGE = Func("reset_image", reset_image)
+
+    def handle_auto_advance(block: Block) -> None:
+        LD.HL_mn16(block, AUTO_INTERVAL_ADDR)
+        LD.A_H(block)
+        OR.L(block)
+        JR_Z(block, "auto_end")
+
+        LD.HL_mn16(block, LAST_JIFFY_ADDR)
+        LD.D_H(block)
+        LD.E_L(block)
+
+        LD.HL_mn16(block, JIFFY_ADDR)
+        LD.B_H(block)
+        LD.C_L(block)
+
+        LD.A_L(block)
+        CP.E(block)
+        JR_NZ(block, "auto_tick_changed")
+        LD.A_H(block)
+        CP.D(block)
+        JR_NZ(block, "auto_tick_changed")
+        JR(block, "auto_end")
+
+        block.label("auto_tick_changed")
+        XOR.A(block)
+        block.emit(0xED, 0x52)  # SBC HL,DE
+        LD.D_H(block)
+        LD.E_L(block)
+
+        LD.H_B(block)
+        LD.L_C(block)
+        LD.mn16_HL(block, LAST_JIFFY_ADDR)
+
+        LD.HL_mn16(block, AUTO_COUNTDOWN_ADDR)
+        XOR.A(block)
+        block.emit(0xED, 0x52)  # SBC HL,DE
+        JR_C(block, "auto_trigger")
+        LD.A_H(block)
+        OR.L(block)
+        JR_Z(block, "auto_trigger")
+        LD.mn16_HL(block, AUTO_COUNTDOWN_ADDR)
+        JR(block, "auto_end")
+
+        block.label("auto_trigger")
+        NEXT_IMAGE.call(block)
+
+        block.label("auto_end")
+
+    HANDLE_AUTO = Func("handle_auto_advance", handle_auto_advance)
+
+    def speed_up(block: Block) -> None:
+        LD.HL_mn16(block, AUTO_INTERVAL_ADDR)
+        LD.A_H(block)
+        OR.L(block)
+        JR_NZ(block, "speed_up_have_interval")
+        LD.HL_mn16(block, AUTO_INTERVAL_PREV_ADDR)
+        block.label("speed_up_have_interval")
+
+        LD.DE_n16(block, auto_step_ticks)
+        XOR.A(block)
+        block.emit(0xED, 0x52)  # SBC HL,DE
+        JR_C(block, "speed_up_set_min")
+
+        LD.A_H(block)
+        CP.n8(block, (auto_min_ticks >> 8) & 0xFF)
+        JR_C(block, "speed_up_set_min")
+        JR_Z(block, "speed_up_check_low")
+        JR(block, "speed_up_apply")
+
+        block.label("speed_up_check_low")
+        LD.A_L(block)
+        CP.n8(block, auto_min_ticks & 0xFF)
+        JR_C(block, "speed_up_set_min")
+        JR(block, "speed_up_apply")
+
+        block.label("speed_up_set_min")
+        LD.HL_n16(block, auto_min_ticks)
+
+        block.label("speed_up_apply")
+        SET_AUTO_INTERVAL.call(block)
+
+    SPEED_UP = Func("speed_up", speed_up)
+
+    def slow_down(block: Block) -> None:
+        LD.HL_mn16(block, AUTO_INTERVAL_ADDR)
+        LD.A_H(block)
+        OR.L(block)
+        JR_NZ(block, "slow_down_have_interval")
+        LD.HL_mn16(block, AUTO_INTERVAL_PREV_ADDR)
+        block.label("slow_down_have_interval")
+
+        LD.DE_n16(block, auto_step_ticks)
+        ADD.HL_DE(block)
+
+        LD.A_H(block)
+        CP.n8(block, (auto_max_ticks >> 8) & 0xFF)
+        JR_C(block, "slow_down_apply")
+        JR_Z(block, "slow_down_check_low")
+        JR(block, "slow_down_set_max")
+
+        block.label("slow_down_check_low")
+        LD.A_L(block)
+        CP.n8(block, auto_max_ticks & 0xFF)
+        JR_C(block, "slow_down_apply")
+
+        block.label("slow_down_set_max")
+        LD.HL_n16(block, auto_max_ticks)
+
+        block.label("slow_down_apply")
+        SET_AUTO_INTERVAL.call(block)
+
+    SLOW_DOWN = Func("slow_down", slow_down)
+
     b.label("main")
     store_stack_pointer_macro(b)
     enaslt_macro(b)
@@ -142,6 +353,11 @@ def build_boot_bank(
         PRINT_STRING.call(b)
         CALL(b, CHGET)
 
+    LD.HL_n16(b, auto_resume_ticks)
+    LD.mn16_HL(b, AUTO_INTERVAL_PREV_ADDR)
+    LD.HL_n16(b, auto_interval_ticks)
+    SET_AUTO_INTERVAL.call(b)
+
     LD.A_n8(b, 2)
     CALL(b, CHGMOD)
     # set_msx2_palette_default_macro(b)　うまく動いていない
@@ -156,60 +372,82 @@ def build_boot_bank(
     LD.mn16_A(b, CURRENT_INDEX_ADDR)
     LD.C_n8(b, 1)
     LOAD_AND_SHOW.call(b)
+    RESET_AUTO_TIMER.call(b)
 
     b.label("main_loop")
     CALL(b, CHSNS)
     CP.n8(b, 0)
-    JR_Z(b, "main_loop")
+    JR_Z(b, "main_loop_auto")
 
     CALL(b, CHGET)
+    LD.B_A(b)
+    LD.A_n8(b, KEYBOARD_ROW_SHIFT)
+    CALL(b, SNSMAT)
+    LD.D_A(b)
+    LD.A_B(b)
+
     CP.n8(b, KEY_SPACE)
-    JR_Z(b, "key_next")
+    JR_Z(b, "key_space")
     CP.n8(b, KEY_DOWN)
-    JR_Z(b, "key_next")
+    JR_Z(b, "key_down")
     CP.n8(b, KEY_UP)
-    JR_Z(b, "key_prev")
+    JR_Z(b, "key_up")
     CP.n8(b, KEY_ESC)
     JR_Z(b, "key_reset")
     JR(b, "main_loop")
 
+    b.label("key_down")
+    LD.A_D(b)
+    AND.n8(b, KEYBOARD_SHIFT_MASK)
+    JR_NZ(b, "key_next")
+    SLOW_DOWN.call(b)
+    JR(b, "main_loop")
+
+    b.label("key_up")
+    LD.A_D(b)
+    AND.n8(b, KEYBOARD_SHIFT_MASK)
+    JR_NZ(b, "key_prev")
+    SPEED_UP.call(b)
+    JR(b, "main_loop")
+
+    b.label("key_space")
+    LD.HL_mn16(b, AUTO_INTERVAL_ADDR)
+    LD.A_H(b)
+    OR.L(b)
+    JR_Z(b, "key_space_pause_set")
+    LD.mn16_HL(b, AUTO_INTERVAL_PREV_ADDR)
+    b.label("key_space_pause_set")
+    LD.HL_n16(b, 0)
+    SET_AUTO_INTERVAL.call(b)
+    NEXT_IMAGE.call(b)
+    JR(b, "main_loop")
+
     b.label("key_next")
-    LD.A_mn16(b, CURRENT_INDEX_ADDR)
-    INC.A(b)
-    CP.n8(b, image_count)
-    JR_C(b, "store_index")
-    XOR.A(b)
-    b.label("store_index")
-    LD.mn16_A(b, CURRENT_INDEX_ADDR)
-    LD.rr(b, "C", "A")
-    INC.C(b)
-    LOAD_AND_SHOW.call(b)
+    NEXT_IMAGE.call(b)
     JR(b, "main_loop")
 
     b.label("key_prev")
-    LD.A_mn16(b, CURRENT_INDEX_ADDR)
-    OR.A(b)
-    JR_NZ(b, "dec_index")
-    LD.A_n8(b, (image_count - 1) & 0xFF)
-    JR(b, "store_index_prev")
-    b.label("dec_index")
-    DEC.A(b)
-    b.label("store_index_prev")
-    LD.mn16_A(b, CURRENT_INDEX_ADDR)
-    LD.rr(b, "C", "A")
-    INC.C(b)
-    LOAD_AND_SHOW.call(b)
+    PREV_IMAGE.call(b)
     JR(b, "main_loop")
 
     b.label("key_reset")
-    XOR.A(b)
-    LD.mn16_A(b, CURRENT_INDEX_ADDR)
-    LD.C_n8(b, 1)
-    LOAD_AND_SHOW.call(b)
+    RESET_IMAGE.call(b)
+    JR(b, "main_loop")
+
+    b.label("main_loop_auto")
+    HANDLE_AUTO.call(b)
     JR(b, "main_loop")
 
     LOAD_AND_SHOW.define(b)
     PRINT_STRING.define(b)
+    RESET_AUTO_TIMER.define(b)
+    SET_AUTO_INTERVAL.define(b)
+    NEXT_IMAGE.define(b)
+    PREV_IMAGE.define(b)
+    RESET_IMAGE.define(b)
+    HANDLE_AUTO.define(b)
+    SPEED_UP.define(b)
+    SLOW_DOWN.define(b)
     b.label("INSTR_TEXT")
     DB(b, *INSTRUCTION_TEXT.encode("ascii"), 0x00)
 
@@ -220,6 +458,11 @@ def build_rom(
     images: list[bytes],
     show_instructions: bool,
     background_color: int,
+    auto_interval_ticks: int,
+    auto_step_ticks: int,
+    auto_min_ticks: int,
+    auto_max_ticks: int,
+    auto_resume_ticks: int,
 ) -> bytes:
     image_count = len(images)
     if image_count + 1 > MAX_BANKS:
@@ -227,7 +470,16 @@ def build_rom(
     if not 0 <= background_color <= 0x0F:
         raise ValueError("background_color must be between 0 and 15")
 
-    bank0 = build_boot_bank(image_count, show_instructions, background_color)
+    bank0 = build_boot_bank(
+        image_count,
+        show_instructions,
+        background_color,
+        auto_interval_ticks,
+        auto_step_ticks,
+        auto_min_ticks,
+        auto_max_ticks,
+        auto_resume_ticks,
+    )
     banks = [bank0]
 
     for idx, image in enumerate(images, start=1):
@@ -249,10 +501,20 @@ def parse_args() -> argparse.Namespace:
         help="Input .sc2 files or directories containing .sc2 files (max 255)",
     )
     parser.add_argument("-o", "--output", type=Path, help="Output ROM path")
-    parser.add_argument(
-        "-inst", "--with-instructions",
+    inst_group = parser.add_mutually_exclusive_group()
+    inst_group.add_argument(
+        "-inst",
+        "--with-instructions",
+        dest="with_instructions",
         action="store_true",
-        help="Show a SCREEN0 usage message before the first image",
+        help="Show a SCREEN0 usage message before the first image (default)",
+    )
+    inst_group.add_argument(
+        "-noinst",
+        "--no-instructions",
+        dest="with_instructions",
+        action="store_false",
+        help="Skip the SCREEN0 usage message",
     )
     parser.add_argument(
         "-bg", "--background-color",
@@ -260,6 +522,31 @@ def parse_args() -> argparse.Namespace:
         default=0,
         help="SCREEN2 background color value (0-15, default: 0)",
     )
+    parser.add_argument(
+        "--auto-interval",
+        type=float,
+        default=2.0,
+        help="Seconds per automatic page advance (0 to disable, default: 2.0)",
+    )
+    parser.add_argument(
+        "--auto-step",
+        type=float,
+        default=0.2,
+        help="Seconds to add/subtract per SHIFT+cursor speed adjustment (default: 0.2)",
+    )
+    parser.add_argument(
+        "--min-auto-interval",
+        type=float,
+        default=0.2,
+        help="Minimum seconds allowed for auto advance when adjusting (default: 0.2)",
+    )
+    parser.add_argument(
+        "--max-auto-interval",
+        type=float,
+        default=10.0,
+        help="Maximum seconds allowed for auto advance when adjusting (default: 10.0)",
+    )
+    parser.set_defaults(with_instructions=True)
     return parser.parse_args()
 
 
@@ -302,10 +589,36 @@ def main() -> None:
 
     image_bytes = [sc2_to_vram(path.read_bytes()) for path in sc2_paths]
 
+    if args.auto_step <= 0:
+        raise SystemExit("--auto-step must be greater than 0")
+    if args.min_auto_interval <= 0:
+        raise SystemExit("--min-auto-interval must be greater than 0")
+    if args.max_auto_interval <= 0:
+        raise SystemExit("--max-auto-interval must be greater than 0")
+    if args.min_auto_interval > args.max_auto_interval:
+        raise SystemExit("--min-auto-interval cannot exceed --max-auto-interval")
+    if args.auto_interval < 0:
+        raise SystemExit("--auto-interval must be zero or greater")
+
+    auto_step_ticks = max(1, seconds_to_jiffies(args.auto_step))
+    auto_min_ticks = max(1, seconds_to_jiffies(args.min_auto_interval))
+    auto_max_ticks = max(auto_min_ticks, seconds_to_jiffies(args.max_auto_interval))
+    auto_interval_ticks = seconds_to_jiffies(args.auto_interval)
+    if 0 < auto_interval_ticks < auto_min_ticks:
+        auto_interval_ticks = auto_min_ticks
+    if auto_interval_ticks > auto_max_ticks:
+        auto_interval_ticks = auto_max_ticks
+    auto_resume_ticks = auto_interval_ticks if auto_interval_ticks > 0 else auto_min_ticks
+
     rom_bytes = build_rom(
         image_bytes,
         args.with_instructions,
         args.background_color,
+        auto_interval_ticks,
+        auto_step_ticks,
+        auto_min_ticks,
+        auto_max_ticks,
+        auto_resume_ticks,
     )
     out_path = resolve_output_path(args.output, sc2_paths[0])
     out_path.write_bytes(rom_bytes)


### PR DESCRIPTION
## Summary
- enable the instruction screen by default while keeping a flag to disable it
- add configurable auto-paging timings with CLI options for interval, step, minimum, and maximum values
- implement auto-advance, pause, and speed-adjust logic in the SCREEN2 viewer including SHIFT+cursor controls and SPACE pause behavior

## Testing
- python -m py_compile pyutils/sc2_viewer_rom/src/create_sc2_megarom.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694655b5be9083249226d970fbf38a90)