### PR TITLE
Add JIFFY_ADDR to fallback import

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_sc2_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_sc2_megarom.py
@@ -27,7 +27,7 @@ except ImportError:
         set_msx2_palette_default_macro,
         store_stack_pointer_macro,
     )
-    from mmsxxasmhelper.utils import pad_bytes
+    from mmsxxasmhelper.utils import JIFFY_ADDR, pad_bytes
 
 PAGE_SIZE = 0x4000
 MAX_ROM_SIZE = 0x400000


### PR DESCRIPTION
## Summary
- ensure the ImportError fallback in create_sc2_megarom imports JIFFY_ADDR alongside pad_bytes so auto-advance code works without the packaged helper

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69465de673a88324b368915fd227874b)