### PR TITLE
Add discrete speed levels and sprite indicator

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -682,6 +682,11 @@ class LD:
         LD.rr(b, "H", "B")
 
     @staticmethod
+    def L_A(b: Block) -> None:
+        """LD L,A"""
+        LD.rr(b, "L", "A")
+
+    @staticmethod
     def L_C(b: Block) -> None:
         """LD L,C"""
         LD.rr(b, "L", "C")
@@ -986,6 +991,11 @@ class LD:
         LD (IY+d),n8
         """
         b.emit(0xFD, 0x36, disp & 0xFF, value & 0xFF)
+
+    @staticmethod
+    def DE_label(b: Block, label: str) -> None:
+        pos = b.emit(0x11, 0x00, 0x00)
+        b.add_abs16_fixup(pos + 1, label)
 
     @staticmethod
     def HL_label(b: Block, label: str) -> None:

--- a/pyutils/sc2_viewer_rom/src/create_sc2_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_sc2_megarom.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 try:
-    from mmsxxasmhelper.core import ADD, AND, Block, CALL, CP, DB, DEC, DW, Func, INC, JR, JR_C, JR_NZ, JR_Z, LD, OR, XOR
+    from mmsxxasmhelper.core import ADD, AND, Block, CALL, CP, DB, DEC, DW, Func, INC, JR, JR_C, JR_NC, JR_NZ, JR_Z, LD, OR, XOR
     from mmsxxasmhelper.msxutils import (
         CHGMOD,
         LDIRVM,
@@ -18,7 +18,7 @@ try:
     from mmsxxasmhelper.utils import JIFFY_ADDR, pad_bytes
 except ImportError:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".." / "mmsxxasmhelper" / "src"))
-    from mmsxxasmhelper.core import ADD, AND, Block, CALL, CP, DB, DEC, DW, Func, INC, JR, JR_C, JR_NZ, JR_Z, LD, OR, XOR
+    from mmsxxasmhelper.core import ADD, AND, Block, CALL, CP, DB, DEC, DW, Func, INC, JR, JR_C, JR_NC, JR_NZ, JR_Z, LD, OR, XOR
     from mmsxxasmhelper.msxutils import (
         CHGMOD,
         LDIRVM,


### PR DESCRIPTION
## Summary
- switch auto-advance to eight fixed speed steps and map speed-up/slow-down to level changes
- add an optional top-right sprite speed indicator that redraws after each image load
- refresh CLI options to round auto intervals to the nearest level and toggle the indicator

## Testing
- python -m compileall pyutils/sc2_viewer_rom/src/create_sc2_megarom.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69465f9991f0832487aa85b78a1f4d48)