### PR TITLE
Fix scroll ROM redraw jumps exceeding JR range

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -64,6 +64,7 @@ from mmsxxasmhelper.core import (
     DEC,
     Func,
     INC,
+    JP,
     JR,
     JR_C,
     JR_NC,
@@ -431,7 +432,7 @@ def build_boot_bank(image_entries: Sequence[ImageEntry], fill_byte: int) -> byte
     LD.mn16_A(b, CURRENT_IMAGE_ADDR)
     LD.HL_n16(b, 0)
     LD.mn16_HL(b, SCROLL_OFFSET_ADDR)
-    JR(b, "DRAW_CURRENT_IMAGE")
+    JP(b, "DRAW_CURRENT_IMAGE")
 
     b.label("HANDLE_SCROLL_UP")
     LD.HL_mn16(b, SCROLL_OFFSET_ADDR)
@@ -440,7 +441,7 @@ def build_boot_bank(image_entries: Sequence[ImageEntry], fill_byte: int) -> byte
     JR_Z(b, "MAIN_LOOP")
     DEC.HL(b)
     LD.mn16_HL(b, SCROLL_OFFSET_ADDR)
-    JR(b, "DRAW_CURRENT_IMAGE")
+    JP(b, "DRAW_CURRENT_IMAGE")
 
     b.label("HANDLE_SCROLL_DOWN")
     # Load row count for current image
@@ -480,7 +481,7 @@ def build_boot_bank(image_entries: Sequence[ImageEntry], fill_byte: int) -> byte
     INC.HL(b)
     LD.A_D(b)
     LD.mHL_A(b)
-    JR(b, "DRAW_CURRENT_IMAGE")
+    JP(b, "DRAW_CURRENT_IMAGE")
 
     restore_stack_pointer_macro(b)
 


### PR DESCRIPTION
## Summary
- switch the scroll viewer redraw jumps to absolute JP to prevent JR range overflows
- import the JP helper in the scroll ROM builder

## Testing
- pytest --maxfail=1
- PYTHONPATH=pyutils/mmsxxasmhelper/src:pyutils/sc2_viewer_rom/src python - <<'PY'
import types, sys
sys.modules['PIL']=types.SimpleNamespace(Image=None)
sys.modules['PIL.Image']=types.SimpleNamespace(Image=object, new=lambda *a, **k: object(), open=lambda *a, **k: object())
conv=types.SimpleNamespace(BASIC_COLORS_MSX1={}, parse_color=lambda v:(0,0,0))
sys.modules['simple_sc2_converter']=types.SimpleNamespace(converter=conv)
sys.modules['simple_sc2_converter.converter']=conv
from create_scroll_megarom import build_boot_bank, ImageEntry
build_boot_bank([ImageEntry(1,200)],0xFF)
print('boot build ok')
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694778da47e08324b11421e6903f70f2)