### PR TITLE
Handle multi-bank payload padding

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -455,7 +455,8 @@ def pack_image_into_banks(image: ImageData, fill_byte: int) -> list[bytes]:
 
     payload.extend(image.color)
 
-    padded = bytes(pad_bytes(list(payload), PAGE_SIZE, fill_byte))
+    total_size = ((len(payload) + PAGE_SIZE - 1) // PAGE_SIZE) * PAGE_SIZE
+    padded = bytes(pad_bytes(list(payload), total_size, fill_byte))
     return [padded[i : i + PAGE_SIZE] for i in range(0, len(padded), PAGE_SIZE)]
 
 


### PR DESCRIPTION
## Summary
- pad packed image payloads to the next multiple of page size so large images span multiple banks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eaab4bf248324ab0e9acc90f52127)