### PR TITLE
Add test verifying debug debug labels are preserved in ROM

### DIFF
--- a/tests/test_debug_labels.py
+++ b/tests/test_debug_labels.py
@@ -1,0 +1,52 @@
+"""Sanity checks for debug image label embedding.
+
+This test focuses on the debug image generation path of
+``pyutils/sc2_viewer_rom/src/create_scroll_megarom.py``.  The module depends
+on optional third-party packages (Pillow and simple_sc2_converter) that are not
+required for the label-packing logic.  The fixtures below stub those modules so
+that we can import and exercise the builder without installing extra
+dependencies.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _import_create_scroll_megarom(monkeypatch):
+    """Import the ROM builder with minimal stubs for optional dependencies."""
+
+    # The assembler helper lives in the repository; make it importable.
+    monkeypatch.syspath_prepend("pyutils/mmsxxasmhelper/src")
+
+    # Stub Pillow
+    pil = types.ModuleType("PIL")
+    pil.Image = object
+    monkeypatch.setitem(sys.modules, "PIL", pil)
+    monkeypatch.setitem(sys.modules, "PIL.Image", pil)
+
+    # Stub simple_sc2_converter
+    converter = types.SimpleNamespace(BASIC_COLORS_MSX1=None, parse_color=lambda value: value)
+    ssc = types.ModuleType("simple_sc2_converter")
+    ssc.converter = converter
+    monkeypatch.setitem(sys.modules, "simple_sc2_converter", ssc)
+    monkeypatch.setitem(sys.modules, "simple_sc2_converter.converter", converter)
+
+    return importlib.import_module("pyutils.sc2_viewer_rom.src.create_scroll_megarom")
+
+
+def test_debug_labels_include_lowercase(monkeypatch):
+    mod = _import_create_scroll_megarom(monkeypatch)
+
+    rom = mod.build(mod.create_debug_image_data_list(2))
+
+    # Pattern label should be present near the start of the pattern bank
+    assert rom.find(b"PATTERN[2] SCROLL VIEWER DEBUG") >= mod.PAGE_SIZE
+
+    # Color label is lower-case and lives at the beginning of the color bank
+    color_pos = rom.find(b"color[2] scroll viewer debug")
+    assert color_pos >= mod.PAGE_SIZE * 2
+    assert color_pos % mod.PAGE_SIZE == 0
+


### PR DESCRIPTION
## Summary
- add regression test that stubs optional dependencies and confirms debug labels are embedded in the generated ROM banks

## Testing
- python -m pytest tests/test_debug_labels.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ebd237f508324bc368c05dbd20c8e)