### PR TITLE
Refine scroll ROM headers and packing

### DIFF
--- a/tests/test_debug_labels.py
+++ b/tests/test_debug_labels.py
@@ -47,6 +47,6 @@ def test_debug_labels_include_lowercase(monkeypatch):
 
     # Color label is lower-case and lives at the beginning of the color bank
     color_pos = rom.find(b"color[2] scroll viewer debug")
-    assert color_pos >= mod.PAGE_SIZE * 2
-    assert color_pos % mod.PAGE_SIZE == 0
+    expected_color_pos = mod.PAGE_SIZE + mod.PATTERN_RAM_SIZE
+    assert color_pos == expected_color_pos
 


### PR DESCRIPTION
## Summary
- store per-image header entries after the program including start bank, row count, and color data location with an end marker
- pack pattern generator and color table data contiguously across banks and use the new header info during boot
- adjust the debug label test to reflect the contiguous data layout

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f950c12b0832489743960b8aad6e4)