### PR TITLE
Fix scroll ROM viewer quantized image log output

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -756,12 +756,13 @@ def main() -> None:
 
                 quantized_path = run_msx1pq_cli(msx1pq_cli, prepared_path, workdir)
                 os.unlink(prepared_path)
-                quantized_image = Image.open(quantized_path)
-                log_and_store(
-                    f"* quantized iamge #{idx} {quantized_path} created",
-                    log_lines,
-                )
-                image_data = build_image_data_from_image(quantized_image)
+                with Image.open(quantized_path) as quantized_image:
+                    width, height = quantized_image.size
+                    log_and_store(
+                        f"* quantized image #{idx} {quantized_path} created ({width}x{height}px)",
+                        log_lines,
+                    )
+                    image_data = build_image_data_from_image(quantized_image)
                 image_data_list.append(image_data)
 
     if not image_data_list:


### PR DESCRIPTION
## Summary
- fix typo in scroll ROM viewer quantization log output
- include quantized image dimensions in the log entry and ensure the image file is properly closed

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fa2810bf483249f656c8b8b0529b2)