### PR TITLE
Clamp scroll viewer copy length to screen rows

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -419,7 +419,7 @@ def build_boot_bank(
     # コピーサイズを決める。
     LD.A_mn16(b, CURRENT_IMAGE_ROW_COUNT_ADDR)
     CP.n8(b, SCREEN_TILE_ROWS)
-    JR_NC(b, "ROW_COUNT_OK")
+    JR_C(b, "ROW_COUNT_OK")
     LD.A_n8(b, SCREEN_TILE_ROWS)
     b.label("ROW_COUNT_OK")
     LD.B_A(b)
@@ -439,7 +439,7 @@ def build_boot_bank(
     # 色データも表示領域分だけ読み出す。
     LD.A_mn16(b, CURRENT_IMAGE_ROW_COUNT_ADDR)
     CP.n8(b, SCREEN_TILE_ROWS)
-    JR_NC(b, "ROW_COUNT_OK_COLOR")
+    JR_C(b, "ROW_COUNT_OK_COLOR")
     LD.A_n8(b, SCREEN_TILE_ROWS)
     b.label("ROW_COUNT_OK_COLOR")
     LD.B_A(b)


### PR DESCRIPTION
## Summary
- clamp pattern and color copy counts to SCREEN_TILE_ROWS when building the boot bank

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fa731d4b083248d2241189de8406b)