### PR TITLE
Add debug helper for finalized label addresses

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
@@ -16,6 +16,7 @@ __all__ = [
     "loop_infinite_macro",
     "set_debug",
     "debug_trap",
+    "debug_print_labels",
     "print_bytes",
     "with_register_preserve",
 ]
@@ -170,6 +171,25 @@ def debug_trap(b: Block) -> None:
     if not DEBUG:
         return
     HALT(b)
+
+
+#
+# finalize 後に決定したラベルアドレスを表示するデバッグ用ヘルパー
+#
+
+def debug_print_labels(b: Block, origin: int = 0, *, stream=None) -> None:
+    """finalize 後に決定したラベルアドレスをダンプする。"""
+
+    if not DEBUG:
+        return
+
+    if stream is None:
+        import sys
+
+        stream = sys.stdout
+
+    for name, offset in sorted(b.labels.items(), key=lambda item: item[1]):
+        print(f"{origin + offset:04x}: {name}", file=stream)
 
 
 #

--- a/tests/test_debug_print_labels.py
+++ b/tests/test_debug_print_labels.py
@@ -1,0 +1,51 @@
+from io import StringIO
+from pathlib import Path
+import sys
+
+import pytest
+
+# Make assembler helper importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "pyutils/mmsxxasmhelper/src"))
+
+from mmsxxasmhelper.core import Block, JR, NOP  # noqa: E402
+from mmsxxasmhelper import utils  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def restore_debug_flag():
+    # Ensure DEBUG flag is reset after each test to avoid cross-test pollution.
+    yield
+    utils.set_debug(True)
+
+
+def test_debug_print_labels_outputs_addresses():
+    b = Block()
+    b.label("start")
+    NOP(b)
+    NOP(b)
+    b.label("loop")
+    JR(b, "loop")
+
+    b.finalize(origin=0x4000)
+
+    buffer = StringIO()
+    utils.debug_print_labels(b, origin=0x4000, stream=buffer)
+
+    assert buffer.getvalue().splitlines() == [
+        "4000: start",
+        "4002: loop",
+    ]
+
+
+def test_debug_print_labels_respects_debug_flag():
+    utils.set_debug(False)
+
+    b = Block()
+    b.label("no_output")
+
+    b.finalize()
+
+    buffer = StringIO()
+    utils.debug_print_labels(b, origin=0x8000, stream=buffer)
+
+    assert buffer.getvalue() == ""


### PR DESCRIPTION
## Summary
- add a debug helper to print label addresses after block finalization
- expose helper in utils exports for easy use
- cover new helper with tests and ensure debug flag gating

## Testing
- pytest tests/test_debug_print_labels.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952bc6887a08324b252f16f7c3e88b4)