### PR TITLE
Add BIT instruction support to asm helper core

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -67,7 +67,7 @@ __all__ = [
     "RET", "RET_NZ", "RET_Z", "RET_NC", "RET_C", "RET_PO", "RET_PE", "RET_P", "RET_M",
     "Func",
     "DB", "DW",
-    "LD", "ADD", "SUB", "CP", "AND", "OR", "XOR",
+    "LD", "ADD", "SUB", "CP", "AND", "OR", "XOR", "BIT",
     "CPL", "NEG",
     "LDIR",
     "RLCA",
@@ -1693,6 +1693,56 @@ class XOR:
         """XOR n8"""
 
         b.emit(0xEE, value & 0xFF)
+
+
+class BIT:
+    """BIT n,r 系命令。"""
+
+    _REG8_INDEX = {
+        "B": 0,
+        "C": 1,
+        "D": 2,
+        "E": 3,
+        "H": 4,
+        "L": 5,
+        "mHL": 6,
+        "A": 7,
+    }
+
+    @staticmethod
+    def r(b: Block, bit: int, reg: str) -> None:
+        """BIT bit,reg
+
+        reg は "A","B","C","D","E","H","L","mHL" のいずれか。
+        bit は 0〜7 を指定する。
+        """
+
+        if not 0 <= bit <= 7:
+            raise ValueError("bit must be in 0..7")
+        try:
+            r_index = BIT._REG8_INDEX[reg]
+        except KeyError as exc:
+            raise ValueError(f"invalid BIT reg operand: {reg}") from exc
+        opcode = 0x40 | (bit << 3) | r_index
+        b.emit(0xCB, opcode)
+
+    @staticmethod
+    def mIXd(b: Block, bit: int, disp: int) -> None:
+        """BIT bit,(IX+d)"""
+
+        if not 0 <= bit <= 7:
+            raise ValueError("bit must be in 0..7")
+        opcode = 0x40 | (bit << 3) | 6
+        b.emit(0xDD, 0xCB, disp & 0xFF, opcode)
+
+    @staticmethod
+    def mIYd(b: Block, bit: int, disp: int) -> None:
+        """BIT bit,(IY+d)"""
+
+        if not 0 <= bit <= 7:
+            raise ValueError("bit must be in 0..7")
+        opcode = 0x40 | (bit << 3) | 6
+        b.emit(0xFD, 0xCB, disp & 0xFF, opcode)
 
 # ---------------------------------------------------------------------------
 # ビット操作

--- a/tests/test_bit_instruction.py
+++ b/tests/test_bit_instruction.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "pyutils/mmsxxasmhelper/src"))
+
+from mmsxxasmhelper.core import BIT, Block  # noqa: E402
+
+
+def test_bit_r_emits_cb_prefixed_opcode():
+    b = Block()
+
+    BIT.r(b, 0, "B")
+    BIT.r(b, 7, "A")
+    BIT.r(b, 3, "mHL")
+
+    assert b.finalize() == bytes(
+        [
+            0xCB, 0x40,  # BIT 0,B
+            0xCB, 0x7F,  # BIT 7,A
+            0xCB, 0x5E,  # BIT 3,(HL)
+        ]
+    )
+
+
+def test_bit_ix_iy_displacement_variants():
+    b = Block()
+
+    BIT.mIXd(b, 2, 0x12)
+    BIT.mIYd(b, 6, -1)
+
+    assert b.finalize() == bytes(
+        [
+            0xDD, 0xCB, 0x12, 0x56,  # BIT 2,(IX+0x12)
+            0xFD, 0xCB, 0xFF, 0x76,  # BIT 6,(IY-1)
+        ]
+    )
+


### PR DESCRIPTION
## Summary
- add BIT n,r instruction helpers to the assembler helper core
- provide IX/IY displacement variants and register validation
- add unit tests covering BIT encodings

## Testing
- pytest tests/test_bit_instruction.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695344c464d48324abd70f12c9a6f0f3)