### PR TITLE
Add helper to define created Funcs

### DIFF
--- a/tests/test_define_created_funcs.py
+++ b/tests/test_define_created_funcs.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "pyutils/mmsxxasmhelper/src"))
+
+import mmsxxasmhelper.core as core
+
+
+def _func_body(value: int):
+    def _body(block: core.Block) -> None:
+        block.emit(value)
+
+    return _body
+
+
+def test_define_created_funcs_excludes_by_name_and_reference(monkeypatch):
+    monkeypatch.setattr(core, "_created_funcs", [], raising=False)
+
+    func_a = core.Func("FUNC_A", _func_body(0x00))
+    func_b = core.Func("FUNC_B", _func_body(0x01))
+    core.Func("FUNC_SKIP", _func_body(0x02))
+
+    block = core.Block()
+
+    core.define_created_funcs(block, "FUNC_SKIP", func_a)
+
+    assert "FUNC_A" not in block.labels
+    assert "FUNC_SKIP" not in block.labels
+    assert block.labels[func_b.name] == 0
+    assert bytes(block.code) == bytes([0x01, 0xC9])


### PR DESCRIPTION
## Summary
- add automatic tracking for created Func instances and provide a helper to define them with exclusions
- export the new helper from the core module for callers
- add tests covering exclusions by name and reference

## Testing
- python -m pytest tests/test_define_created_funcs.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953644891208324a5068581072410c9)