### PR TITLE
Add INITXT constant to msxutils

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
@@ -31,6 +31,7 @@ __all__ = [
     "build_beep_control_utils",
     "build_set_vram_write_func",
     "build_scroll_name_table_func",
+    "INITXT",
     "VDP_CTRL",
     "VDP_DATA",
     "VDP_PAL",
@@ -44,6 +45,7 @@ LDIRVM = 0x005C  # メモリ→VRAMの連続書込
 CHGMOD = 0x005F  # 画面モード変更
 INIGRP = 0x0072  # SCREEN 初期化
 CHGCLR = 0x0062  # 画面色変更
+INITXT = 0x006C  # SCREEN 0 初期化
 ENASLT = 0x0024  # スロット切り替え
 RSLREG = 0x0138  # 現在のスロット情報取得
 # EXPTBL = 0xFCC1  # 拡張スロット情報


### PR DESCRIPTION
## Summary
- add the INITXT BIOS call constant for SCREEN 0 initialization to `msxutils`
- export the new constant for reuse alongside other MSX BIOS helpers

## Testing
- python -m pytest tests/test_screen0_config_menu.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953fd7fb5a08324b31a94acfcc82127)