### PR TITLE
Raise on undefined Funcs during finalize

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -173,6 +173,12 @@ class Block:
         v0 では単一ブロック前提なので任意指定でOK。
         """
 
+        undefined_funcs = [func.name for func in _created_funcs
+                           if func.name not in self.labels]
+        if undefined_funcs:
+            names = ", ".join(sorted(set(undefined_funcs)))
+            raise ValueError(f"undefined func(s): {names}")
+
         for fx in self.fixups:
             if fx.kind == "abs16":
                 # fx.pos が下位バイト、fx.pos+1 が上位バイト

--- a/tests/test_define_created_funcs.py
+++ b/tests/test_define_created_funcs.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append(str(Path(__file__).resolve().parents[1] / "pyutils/mmsxxasmhelper/src"))
 
 import mmsxxasmhelper.core as core
+import pytest
 
 
 def _func_body(value: int):
@@ -28,3 +29,25 @@ def test_define_created_funcs_excludes_by_name_and_reference(monkeypatch):
     assert "FUNC_SKIP" not in block.labels
     assert block.labels[func_b.name] == 0
     assert bytes(block.code) == bytes([0x01, 0xC9])
+
+
+def test_finalize_errors_when_func_not_defined(monkeypatch):
+    monkeypatch.setattr(core, "_created_funcs", [], raising=False)
+
+    core.Func("UNDEFINED_FUNC", _func_body(0x00))
+
+    block = core.Block()
+
+    with pytest.raises(ValueError, match="undefined func\(s\): UNDEFINED_FUNC"):
+        block.finalize()
+
+
+def test_finalize_allows_defined_funcs(monkeypatch):
+    monkeypatch.setattr(core, "_created_funcs", [], raising=False)
+
+    func = core.Func("DEFINED_FUNC", _func_body(0x10))
+
+    block = core.Block()
+    func.define(block)
+
+    assert block.finalize() == bytes([0x10, 0xC9])


### PR DESCRIPTION
## Summary
- raise an error during `Block.finalize` when any registered `Func` is left undefined
- add tests covering finalize behavior for both undefined and defined functions

## Testing
- PYTHONPATH=. pytest -q tests/test_define_created_funcs.py
- pytest -q *(fails: ModuleNotFoundError: No module named 'pyutils' during existing test import)*
- PYTHONPATH=. pytest -q *(fails: ValueError in create_scroll_megarom setup unrelated to current changes)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954016eaae08324ba3e167442d25db4)