### PR TITLE
Restrict MemAddrAllocator initial values to byte sequences

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
@@ -243,30 +243,16 @@ class MemAddrAllocator:
 
     def _normalize_initial_value(self, value: object) -> list[int]:
         if isinstance(value, (bytes, bytearray)):
-            raw = list(value)
-        elif isinstance(value, int):
-            raw = [value & 0xFF, (value >> 8) & 0xFF]
-        elif isinstance(value, Sequence):
-            if not value:
-                raw = []
-            elif all(isinstance(v, str) for v in value):
-                raw = [ord(v) for v in value]  # type: ignore[arg-type]
-            elif all(isinstance(v, int) for v in value):
-                raw = [int(v) & 0xFF for v in value]
-            else:  # pragma: no cover - defensive branch
-                msg = "initial value sequence must contain int or str elements"
-                raise TypeError(msg)
-        else:  # pragma: no cover - defensive branch
-            msg = "unsupported initial value type"
-            raise TypeError(msg)
+            return list(value)
 
-        return raw
+        msg = "initial value must be bytes or bytearray"
+        raise TypeError(msg)
 
     def add(
         self,
         name: str,
         size: int | None = None,
-        initial_value: object | None = None,
+        initial_value: bytes | bytearray | None = None,
         description: str = "",
     ) -> int:
         """名前とサイズを登録し、割り当て先アドレスを返す。"""
@@ -289,10 +275,6 @@ class MemAddrAllocator:
             size = value_length
         elif value_length is not None and size != value_length:
             msg = f"size ({size}) does not match initial value length ({value_length})"
-            raise ValueError(msg)
-
-        if isinstance(initial_value, int) and size != 2:
-            msg = "16bit initial value requires size=2"
             raise ValueError(msg)
 
         assert size is not None

--- a/tests/test_mem_addr_allocator.py
+++ b/tests/test_mem_addr_allocator.py
@@ -11,10 +11,10 @@ from mmsxxasmhelper.utils import MemAddrAllocator
 def test_add_with_various_initial_values() -> None:
     allocator = MemAddrAllocator(0x8000)
 
-    allocator.add("BUFFER", 4, initial_value=[0x01, 0x02, 0x00, 0x00])
-    allocator.add("CHARS", 3, initial_value=["A", "B", "C"])
-    allocator.add("WORD", 2, initial_value=0x1234)
-    allocator.add("BYTES", initial_value=b"\xAA\xBB")
+    allocator.add("BUFFER", 4, initial_value=b"\x01\x02\x00\x00")
+    allocator.add("CHARS", 3, initial_value=b"ABC")
+    allocator.add("WORD", 2, initial_value=bytes([0x34, 0x12]))
+    allocator.add("BYTES", initial_value=bytearray(b"\xAA\xBB"))
 
     assert allocator.get("BUFFER") == 0x8000
     assert allocator.get("CHARS") == 0x8004
@@ -34,7 +34,7 @@ def test_add_with_various_initial_values() -> None:
 def test_write_initial_values_fills_target_buffer() -> None:
     allocator = MemAddrAllocator(0xC000)
 
-    allocator.add("WORD", 2, initial_value=0xBEEF)
+    allocator.add("WORD", 2, initial_value=bytes([0xEF, 0xBE]))
     allocator.add("BUFFER", 3)
     allocator.add("BYTE", 1, initial_value=b"\x7F")
 
@@ -49,7 +49,7 @@ def test_add_rejects_invalid_16bit_size() -> None:
 
     # size=1 に 16bit を設定しようとするとエラー
     with pytest.raises(ValueError):
-        allocator.add("INVALID", 1, initial_value=0x1234)
+        allocator.add("INVALID", 1, initial_value=b"\x34\x12")
 
 
 def test_add_requires_length_information() -> None:
@@ -63,13 +63,13 @@ def test_add_raises_on_size_value_mismatch() -> None:
     allocator = MemAddrAllocator(0x5000)
 
     with pytest.raises(ValueError):
-        allocator.add("TOO_SHORT", 3, initial_value=[0x01, 0x02])
+        allocator.add("TOO_SHORT", 3, initial_value=b"\x01\x02")
 
 
 def test_add_allows_size_inference_from_initial_value() -> None:
     allocator = MemAddrAllocator(0x6000)
 
-    addr = allocator.add("AUTO", initial_value=[0x10, 0x20, 0x30])
+    addr = allocator.add("AUTO", initial_value=b"\x10\x20\x30")
 
     assert addr == 0x6000
     assert allocator.total_size == 3


### PR DESCRIPTION
## Summary
- enforce that MemAddrAllocator only accepts byte or bytearray initial values
- update allocator tests to supply byte sequences and cover size validation

## Testing
- python -m pytest tests/test_mem_addr_allocator.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69540d7d952483248ee51c0d20444cc8)