### PR TITLE
Fix ROM output overwrite check

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1207,6 +1207,8 @@ def main() -> None:
             name = f"debug_scroll{args.debug_image_index}[ASCII16]"
         out = Path.cwd() / f"{name}.rom"
 
+    ensure_output_writable(out)
+
     try:
         out.write_bytes(rom)
     except Exception as exc:  # pragma: no cover - CLI error path


### PR DESCRIPTION
## Summary
- validate user-provided output paths immediately
- ensure defaulted ROM output paths are checked for writability before writing

## Testing
- python -m compileall pyutils/sc2_viewer_rom/src/create_scroll_megarom.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542887b7108324a8d4ebfdc8938baa)