### PR TITLE
Preserve bank increments during scroll row copy

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -664,10 +664,10 @@ def build_sync_scroll_row_func() -> Func:
         LD.DE_n16(block, ADDR.PG_BUFFER)
         for tile_idx in range(32):
             PUSH.HL(block)
-            PUSH.BC(block)
             for line_idx in range(8):
                 # ラベル名をタイルのインデックスに合わせてユニークにする
                 lbl_skip = f"PG_SKIP_{tile_idx}_{line_idx}"
+                lbl_next = f"PG_NEXT_{tile_idx}_{line_idx}"
 
                 LD.A_H(block)
                 CP.n8(block, 0xC0)
@@ -683,11 +683,14 @@ def build_sync_scroll_row_func() -> Func:
                 LD.A_mHL(block)
                 LD.mDE_A(block)
                 INC.DE(block)
-                LD.BC_n16(block, 32)
-                ADD.HL_BC(block)
-            POP.BC(block)
+                LD.A_L(block)
+                ADD.A_n8(block, 32)
+                LD.L_A(block)
+                JR_NC(block, lbl_next)
+                INC.H(block)
+                block.label(lbl_next)
             LD.A_B(block)
-            LD.mn16_A(block, ASCII16_PAGE2_REG)  # バンク戻す
+            LD.mn16_A(block, ASCII16_PAGE2_REG)  # 現在のバンクを反映
             POP.HL(block)
             INC.HL(block)
 
@@ -722,9 +725,9 @@ def build_sync_scroll_row_func() -> Func:
         LD.DE_n16(block, ADDR.CT_BUFFER)
         for tile_idx in range(32):
             PUSH.HL(block)
-            PUSH.BC(block)
             for line_idx in range(8):
                 lbl_ct_skip = f"CT_SKIP_{tile_idx}_{line_idx}"
+                lbl_ct_next = f"CT_NEXT_{tile_idx}_{line_idx}"
 
                 LD.A_H(block)
                 CP.n8(block, 0xC0)
@@ -739,9 +742,12 @@ def build_sync_scroll_row_func() -> Func:
                 LD.A_mHL(block)
                 LD.mDE_A(block)
                 INC.DE(block)
-                LD.BC_n16(block, 32)
-                ADD.HL_BC(block)
-            POP.BC(block)
+                LD.A_L(block)
+                ADD.A_n8(block, 32)
+                LD.L_A(block)
+                JR_NC(block, lbl_ct_next)
+                INC.H(block)
+                block.label(lbl_ct_next)
             LD.A_B(block)
             LD.mn16_A(block, ASCII16_PAGE2_REG)
             POP.HL(block)


### PR DESCRIPTION
## Summary
- preserve updated ROM bank while copying PG/CT rows by avoiding BC save/restore that reset B
- increment source addresses without clobbering the bank register and ensure the active bank register matches the tracked value after each tile

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954dc59606c8324b6250cc1e52dda14)