### PR TITLE
Adjust parameter order for grouped Func definitions

### DIFF
--- a/tests/test_define_created_funcs.py
+++ b/tests/test_define_created_funcs.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import sys
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "pyutils/mmsxxasmhelper/src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "pyutils/mmsxxasmhelper/src"))
 
 import mmsxxasmhelper.core as core
 import pytest
@@ -15,7 +15,7 @@ def _func_body(value: int):
 
 
 def test_define_created_funcs_excludes_by_name_and_reference(monkeypatch):
-    monkeypatch.setattr(core, "_created_funcs", [], raising=False)
+    monkeypatch.setattr(core, "_created_funcs_by_group", {}, raising=False)
 
     func_a = core.Func("FUNC_A", _func_body(0x00))
     func_b = core.Func("FUNC_B", _func_body(0x01))
@@ -23,7 +23,7 @@ def test_define_created_funcs_excludes_by_name_and_reference(monkeypatch):
 
     block = core.Block()
 
-    core.define_created_funcs(block, "FUNC_SKIP", func_a)
+    core.define_created_funcs(block, core._DEFAULT_FUNC_GROUP, "FUNC_SKIP", func_a)
 
     assert "FUNC_A" not in block.labels
     assert "FUNC_SKIP" not in block.labels
@@ -32,7 +32,7 @@ def test_define_created_funcs_excludes_by_name_and_reference(monkeypatch):
 
 
 def test_finalize_errors_when_func_not_defined(monkeypatch):
-    monkeypatch.setattr(core, "_created_funcs", [], raising=False)
+    monkeypatch.setattr(core, "_created_funcs_by_group", {}, raising=False)
 
     core.Func("UNDEFINED_FUNC", _func_body(0x00))
 
@@ -43,7 +43,7 @@ def test_finalize_errors_when_func_not_defined(monkeypatch):
 
 
 def test_finalize_allows_defined_funcs(monkeypatch):
-    monkeypatch.setattr(core, "_created_funcs", [], raising=False)
+    monkeypatch.setattr(core, "_created_funcs_by_group", {}, raising=False)
 
     func = core.Func("DEFINED_FUNC", _func_body(0x10))
 

--- a/tests/test_screen0_config_menu.py
+++ b/tests/test_screen0_config_menu.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import sys
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "pyutils/mmsxxasmhelper/src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "pyutils/mmsxxasmhelper/src"))
 
 import mmsxxasmhelper.core as core
 import mmsxxasmhelper.msxutils as msxutils
@@ -9,7 +9,7 @@ import mmsxxasmhelper.config_scene as config_scene
 
 
 def test_build_screen0_config_menu_generates_bytes(monkeypatch):
-    monkeypatch.setattr(core, "_created_funcs", [], raising=False)
+    monkeypatch.setattr(core, "_created_funcs_by_group", {}, raising=False)
 
     entries = [
         config_scene.Screen0ConfigEntry("MODE", ["MSX1", "MSX2"], 0xC200),


### PR DESCRIPTION
## Summary
- move the group parameter ahead of exceptions in define_created_funcs for clearer invocation
- update tests to call define_created_funcs with the new parameter order

## Testing
- pytest tests/test_define_created_funcs.py tests/test_screen0_config_menu.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956380bf67883249a0ff179b60339d5)