### PR TITLE
Expose default Func group name constant

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -61,6 +61,7 @@ __all__ = [
     "pad_bytes", "const_bytes_padded",
     "pad_pattern",
     "unique_label",
+    "DEFAULT_FUNC_GROUP_NAME",
     "JP", "JP_Z", "JP_NZ", "JP_NC", "JP_C", "JP_PO", "JP_PE", "JP_P", "JP_M", "JP_mHL",
     "JR", "JR_NZ", "JR_Z", "JR_NC", "JR_C", "JR_n8", "DJNZ",
     "CALL_label", "CALL",
@@ -90,7 +91,7 @@ from typing import Callable, Dict, List, Literal
 # ---------------------------------------------------------------------------
 
 _label_counter = count()
-_DEFAULT_FUNC_GROUP = "default"
+DEFAULT_FUNC_GROUP_NAME = "default"
 _created_funcs_by_group: Dict[str, List["Func"]] = {}
 
 
@@ -564,7 +565,7 @@ class Func:
         name: str,
         body: Body,
         no_auto_ret: bool = False,
-        group: str = _DEFAULT_FUNC_GROUP,
+        group: str = DEFAULT_FUNC_GROUP_NAME,
     ) -> None:
         self.name = name
         self.body = body
@@ -588,7 +589,7 @@ class Func:
 
 
 def define_created_funcs(
-    b: Block, group: str = _DEFAULT_FUNC_GROUP, *except_funcs: str | Func
+    b: Block, group: str = DEFAULT_FUNC_GROUP_NAME, *except_funcs: str | Func
 ) -> None:
     """Func で作られた関数をまとめて define するヘルパー。
 

--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
@@ -66,7 +66,12 @@ JIFFY_ADDR = 0xFC9E
 # ---------------------------------------------------------------------------
 
 
-def create_rng_seed_func(rng_state_addr: int, preserve_reg_bc: bool = True):
+def create_rng_seed_func(
+    rng_state_addr: int,
+    preserve_reg_bc: bool = True,
+    *,
+    group: str = DEFAULT_FUNC_GROUP_NAME,
+):
     """
     ランダムシードの値を指定アドレスに描きこむ
     :param rng_state_addr: 読み書きするアドレス
@@ -83,10 +88,15 @@ def create_rng_seed_func(rng_state_addr: int, preserve_reg_bc: bool = True):
             POP.BC(b)
         LD.mn16_A(b, rng_state_addr)
 
-    return Func("create_rng_seed", _create_rng_seed)
+    return Func("create_rng_seed", _create_rng_seed, group=group)
 
 
-def rng_next_func(rng_state_addr: int, preserve_reg_bc: bool = True) -> Func:
+def rng_next_func(
+    rng_state_addr: int,
+    preserve_reg_bc: bool = True,
+    *,
+    group: str = DEFAULT_FUNC_GROUP_NAME,
+) -> Func:
     """
     古典的簡易ランダムアルゴリズム
     あるアドレスの値を次のランダム値に更新する Aレジスタに更新後の値を返す
@@ -110,7 +120,7 @@ def rng_next_func(rng_state_addr: int, preserve_reg_bc: bool = True) -> Func:
             POP.BC(b)
         RET(b)
 
-    return Func("rng_next", _rng_next)
+    return Func("rng_next", _rng_next, group=group)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_define_created_funcs.py
+++ b/tests/test_define_created_funcs.py
@@ -23,7 +23,7 @@ def test_define_created_funcs_excludes_by_name_and_reference(monkeypatch):
 
     block = core.Block()
 
-    core.define_created_funcs(block, core._DEFAULT_FUNC_GROUP, "FUNC_SKIP", func_a)
+    core.define_created_funcs(block, core.DEFAULT_FUNC_GROUP_NAME, "FUNC_SKIP", func_a)
 
     assert "FUNC_A" not in block.labels
     assert "FUNC_SKIP" not in block.labels


### PR DESCRIPTION
## Summary
- rename the default function group constant to `DEFAULT_FUNC_GROUP_NAME` and export it from core
- update utils, msxutils, and tests to import and use the shared constant

## Testing
- python -m pytest tests/test_define_created_funcs.py
- python -m compileall pyutils/mmsxxasmhelper/src


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69563a0fe4348324a3361f9a3eadd0b4)