### PR TITLE
Update finalize group handling signature

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -83,7 +83,7 @@ __all__ = [
 
 from dataclasses import dataclass
 from itertools import count
-from typing import Callable, Dict, List, Literal
+from typing import Callable, Dict, List, Literal, Optional
 
 
 # ---------------------------------------------------------------------------
@@ -168,17 +168,18 @@ class Block:
 
     # --- 出力確定 ---
 
-    def finalize(self, origin: int = 0) -> bytes:
+    def finalize(self, origin: int = 0, groups: Optional[List[str]] = None) -> bytes:
         """fixupを解決してバイト列を返す。
 
         origin はこの Block をメモリ上のどこに配置するかのベースアドレス。
         v0 では単一ブロック前提なので任意指定でOK。
         """
 
+        groups_to_check = groups or [DEFAULT_FUNC_GROUP_NAME]
         undefined_funcs = [
             func.name
-            for funcs in _created_funcs_by_group.values()
-            for func in funcs
+            for group in groups_to_check
+            for func in _created_funcs_by_group.get(group, [])
             if func.name not in self.labels
         ]
         if undefined_funcs:

--- a/tests/test_define_created_funcs.py
+++ b/tests/test_define_created_funcs.py
@@ -42,6 +42,32 @@ def test_finalize_errors_when_func_not_defined(monkeypatch):
         block.finalize()
 
 
+def test_finalize_checks_only_default_group_when_unspecified(monkeypatch):
+    monkeypatch.setattr(core, "_created_funcs_by_group", {}, raising=False)
+
+    core.Func("UNDEFINED_OTHER_GROUP", _func_body(0x00), group="other")
+
+    block = core.Block()
+
+    # group="other" の func は対象外なのでエラーにならない
+    block.finalize()
+
+
+def test_finalize_checks_specified_groups(monkeypatch):
+    monkeypatch.setattr(core, "_created_funcs_by_group", {}, raising=False)
+
+    core.Func("UNDEFINED_DEFAULT", _func_body(0x00))
+    core.Func("UNDEFINED_GROUP", _func_body(0x01), group="grp")
+
+    block = core.Block()
+
+    with pytest.raises(ValueError, match="UNDEFINED_GROUP"):
+        block.finalize(0, ["grp"])
+
+    with pytest.raises(ValueError, match="UNDEFINED_DEFAULT, UNDEFINED_GROUP"):
+        block.finalize(0, [core.DEFAULT_FUNC_GROUP_NAME, "grp"])
+
+
 def test_finalize_allows_defined_funcs(monkeypatch):
     monkeypatch.setattr(core, "_created_funcs_by_group", {}, raising=False)
 


### PR DESCRIPTION
## Summary
- accept finalize groups as an explicit list parameter rather than variadic args
- keep undefined function checks scoped to specified groups with default fallback
- adjust related tests to pass group lists explicitly

## Testing
- pytest tests/test_define_created_funcs.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69564fe3c0048324ba7fe674fc54a883)