### PR TITLE
Log Func body byte size when defining

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -578,9 +578,11 @@ class Func:
         """関数本体を配置する (label + body + RET)。"""
 
         self.define_label_only(b)
+        start_pc = b.pc
         self.body(b)
+        body_size = b.pc - start_pc
 
-        print(f"Func defined: {self.name} (no_auto_ret={self.no_auto_ret})")
+        print(f"Func defined: {self.name} (body_size={body_size})")
 
         if not self.no_auto_ret:
             # RET


### PR DESCRIPTION
## Summary
- measure bytes emitted by a `Func` body during definition
- report the generated body size when logging the function definition instead of the `no_auto_ret` flag

## Testing
- python -m pytest *(fails: tests/test_debug_labels.py::test_debug_labels_include_lowercase; tests/test_debug_print_labels.py::test_debug_print_labels_outputs_addresses; tests/test_debug_print_labels.py::test_debug_print_labels_respects_debug_flag)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69566b74d4708324a16ad73979863e0c)