### PR TITLE
Support offset Func calls for banked routines

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1024,7 +1024,6 @@ def build_boot_bank(
     JP(b, "MAIN_LOOP")
     # --- 関数定義 ---
     define_created_funcs(b, group=DEFAULT_FUNC_GROUP_NAME)
-    define_all_created_funcs_label_only(b, group=OUTI_FUNCS_GROUP)
 
     # --- [事前計算テーブル群] ---
     # 1. 名前テーブル用 MOD 24 テーブル (行数 0-255 -> 0-23)


### PR DESCRIPTION
## Summary
- allow CALL fixups and Func.call to apply compile-time address offsets, enabling banked routines to be invoked at different page bases
- track defined function positions for immediate calls when offsets are supplied
- avoid inserting placeholder OUTI function labels into the boot bank so banked routines are not misaddressed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69569e72a77483249d8ef6e3cbf81ae4)