### PR TITLE
Add offset-aware label logging

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
@@ -188,13 +188,21 @@ def debug_trap(b: Block) -> None:
 # finalize 後に決定したラベルアドレスを表示するデバッグ用ヘルパー
 #
 
-def debug_print_labels(b: Block, origin: int = 0, *, stream=None, no_print: bool = False) -> str:
+def debug_print_labels(
+    b: Block,
+    origin: int = 0,
+    *,
+    stream=None,
+    no_print: bool = False,
+    include_offset: bool = False,
+) -> str:
     """
     finalize 後に決定したラベルアドレスをダンプする。
     :param b: Block
-    :param origin: アドレスの
+    :param origin: アドレスの基点
     :param stream:
     :param no_print: print しない（でテキストだけ得る）
+    :param include_offset: オフセットも併記する
     """
 
     if not DEBUG:
@@ -207,7 +215,11 @@ def debug_print_labels(b: Block, origin: int = 0, *, stream=None, no_print: bool
 
     messages = []
     for name, offset in sorted(b.labels.items(), key=lambda item: item[1]):
-        message = f"{origin + offset:04X}: {name}"
+        absolute = origin + offset
+        if include_offset:
+            message = f"{absolute:04X} (+{offset:04X}): {name}"
+        else:
+            message = f"{absolute:04X}: {name}"
         messages.append(message)
         if not no_print:
             print(message, file=stream)

--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1045,7 +1045,10 @@ def build_boot_bank(
 
     data = bytes(pad_bytes(list(assembled), PAGE_SIZE, fill_byte))
     log_and_store("---- labels ----", log_lines)
-    log_and_store(debug_print_labels(b, origin=0x4000, no_print=True), log_lines)
+    log_and_store(
+        debug_print_labels(b, origin=0x4000, no_print=True, include_offset=True),
+        log_lines,
+    )
 
     used_bytes = len(assembled)
     if used_bytes > PAGE_SIZE:
@@ -1089,7 +1092,10 @@ def build_outi_funcs_bank(
         log_lines,
     )
     log_and_store("---- labels ----", log_lines)
-    log_and_store(debug_print_labels(b, origin=0, no_print=True), log_lines)
+    log_and_store(
+        debug_print_labels(b, origin=0, no_print=True, include_offset=True),
+        log_lines,
+    )
 
     banks = [data[i : i + PAGE_SIZE] for i in range(0, len(data), PAGE_SIZE)]
     ensure_funcs_defined(OUTI_FUNCS)

--- a/tests/test_debug_print_labels.py
+++ b/tests/test_debug_print_labels.py
@@ -37,6 +37,23 @@ def test_debug_print_labels_outputs_addresses():
     ]
 
 
+def test_debug_print_labels_outputs_offsets():
+    b = Block()
+    b.label("zero")
+    NOP(b)
+    b.label("one")
+
+    b.finalize(origin=0x1234)
+
+    buffer = StringIO()
+    utils.debug_print_labels(b, origin=0x1234, stream=buffer, include_offset=True)
+
+    assert buffer.getvalue().splitlines() == [
+        "1234 (+0000): zero",
+        "1235 (+0001): one",
+    ]
+
+
 def test_debug_print_labels_respects_debug_flag():
     utils.set_debug(False)
 


### PR DESCRIPTION
## Summary
- add optional offset display to `debug_print_labels`
- include offset information when dumping scroll viewer labels
- add coverage for offset-aware label output

## Testing
- python -m pytest tests/test_debug_print_labels.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956af9bd9748324a03067a450d14f2c)