### PR TITLE
Process scroll image segments separately before ROM concat

### DIFF
--- a/tests/test_debug_labels.py
+++ b/tests/test_debug_labels.py
@@ -42,11 +42,13 @@ def test_debug_labels_include_lowercase(monkeypatch):
 
     rom = mod.build(mod.create_debug_image_data_list(2))
 
+    pattern_pos = rom.find(b"PATTERN[2] SCROLL VIEWER DEBUG")
+
     # Pattern label should be present near the start of the pattern bank
-    assert rom.find(b"PATTERN[2] SCROLL VIEWER DEBUG") >= mod.PAGE_SIZE
+    assert pattern_pos >= mod.PAGE_SIZE
 
     # Color label is lower-case and lives at the beginning of the color bank
     color_pos = rom.find(b"color[2] scroll viewer debug")
-    expected_color_pos = mod.PAGE_SIZE + mod.PATTERN_RAM_SIZE
+    expected_color_pos = pattern_pos + mod.PATTERN_RAM_SIZE
     assert color_pos == expected_color_pos
 


### PR DESCRIPTION
## Summary
- keep scroll input groups split through quantization and concatenate the resulting ImageData when building the ROM
- add validation and concatenation helpers for ImageData to support segmented processing
- update the debug label test to derive the expected color label position from the pattern data offset

## Testing
- python -m pytest tests/test_debug_labels.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956bedc48a0832498428bd4d465545f)