### PR TITLE
Adjust title countdown exit timing

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/title_scene.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/title_scene.py
@@ -194,10 +194,6 @@ def build_title_screen_func(
         JP_NZ(block, EXIT_START)
 
         if countdown_seconds > 0:
-            LD.A_mn16(block, title_seconds_remaining_addr)
-            OR.A(block)
-            JR_Z(block, EXIT_START)
-
             LD.A_mn16(block, title_frame_counter_addr)
             DEC.A(block)
             LD.mn16_A(block, title_frame_counter_addr)
@@ -211,9 +207,9 @@ def build_title_screen_func(
             LD.A_mn16(block, title_seconds_remaining_addr)
             DEC.A(block)
             LD.mn16_A(block, title_seconds_remaining_addr)
-            write_countdown_digits(block)
-            OR.A(block)
+            CP.n8(block, 0xFF)
             JP_Z(block, EXIT_START)
+            write_countdown_digits(block)
 
         JP(block, LOOP_LABEL)
 


### PR DESCRIPTION
## Summary
- ensure the title countdown waits through zero and exits when the value underflows
- prevent the countdown from rendering a -1 value before leaving the title scene

## Testing
- python -m compileall pyutils/mmsxxasmhelper/src/mmsxxasmhelper/title_scene.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e8ed35c08324a84236e265e6bd87)