### PR TITLE
Handle ESC input in viewer and fix help alignment

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
@@ -521,6 +521,8 @@ def build_update_input_func(
         group: str = DEFAULT_FUNC_GROUP_NAME,
 ) -> Func:
     SNSMAT = 0x0141
+    CHSNS = 0x009C
+    CHGET = 0x009F
     GTSTCK = 0x00D5
     GTTRIG = 0x00D8
 
@@ -615,6 +617,17 @@ def build_update_input_func(
         OR.IXL(block)
         LD.IXL_A(block)
         block.label("_SKIP_SHIFT")
+
+        # ESC キー (キーボードバッファ)
+        CALL(block, CHSNS)
+        JR_Z(block, "_SKIP_ESC")
+        CALL(block, CHGET)
+        CP.n8(block, 0x1B)
+        JR_NZ(block, "_SKIP_ESC")
+        LD.A_n8(block, 1 << INPUT_KEY_BIT.L_ESC)
+        OR.IXL(block)
+        LD.IXL_A(block)
+        block.label("_SKIP_ESC")
 
         # --- 4. HOLD / TRG 更新 ---
         LD.A_IXL(block)

--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -861,7 +861,7 @@ def build_dummy_config_scene_func(
 
         for y, line in enumerate(help_lines):
             write_text_with_cursor_macro(
-                block, line, 0, y
+                block, line, 1, y
             )
 
         # 入力状態を一度更新してトリガーをリセット


### PR DESCRIPTION
## Summary
- add ESC key detection to the shared input update routine so the viewer can open and exit settings with ESC
- adjust the scroll viewer help text position so the copy renders correctly

## Testing
- PYTHONPATH=pyutils/mmsxxasmhelper/src pytest tests/test_screen0_config_menu.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ea754240832485017a4bedff4166)