### PR TITLE
Handle ESC navigation in scroll viewer

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/title_scene.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/title_scene.py
@@ -188,6 +188,10 @@ def build_title_screen_func(
         HALT(block)
         update_input_func.call(block)
 
+        LD.A_mn16(block, input_trg_addr)
+        BIT.n8_A(block, INPUT_KEY_BIT.L_ESC)
+        JP_NZ(block, EXIT_ESC)
+
         CALL(block, chsns)
         JR_Z(block, "TITLE_SKIP_KBD")
         CALL(block, chget)

--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1027,16 +1027,8 @@ def build_boot_bank(
     JR_Z(b, "CHECK_UP")
     CONFIG_SCENE_FUNC.call(b)
     apply_viewer_screen_settings(b)
-    RESET_NAME_TABLE_FUNC.call(b)
-
-    # 現在のスクロール位置に合わせて名前テーブルを補正
-    LD.A_mn16(b, ADDR.CURRENT_SCROLL_ROW)
-    LD.L_A(b)
-    LD.H_n8(b, 0)
-    LD.DE_label(b, "TABLE_MOD24")
-    ADD.HL_DE(b)
-    LD.A_mHL(b)
-    SCROLL_NAME_TABLE_FUNC.call(b)
+    LD.A_mn16(b, ADDR.CURRENT_IMAGE_ADDR)
+    UPDATE_IMAGE_DISPLAY_FUNC.call(b)
     JP(b, "MAIN_LOOP")
 
     b.label("CHECK_UP")


### PR DESCRIPTION
## Summary
- detect ESC presses via the standard input trigger on the title screen so settings can be opened
- redraw the current image after leaving the settings scene to avoid a blank display

## Testing
- python -m pytest *(fails: test_unique_label expectations for label counter prefix differ from current output)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ecfe5b8483248b80b06ab08f64d8)