### PR TITLE
Adjust title screen vertical offset

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/title_scene.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/title_scene.py
@@ -67,7 +67,8 @@ def build_title_screen_func(
     logo_lines = logo_full_text.rstrip("\n").split("\n") if logo_full_text else []
     title_logo_width = max((len(line) for line in logo_lines), default=0)
     title_logo_x = (40 - title_logo_width) // 2 if logo_lines else 0
-    title_logo_y = 2 if logo_lines else 0
+    vertical_offset = 4
+    title_logo_y = vertical_offset
     title_subtext_lines = [
         "",
         "",
@@ -78,7 +79,9 @@ def build_title_screen_func(
         "",
     ]
     title_subtext_x = [(40 - len(line)) // 2 for line in title_subtext_lines]
-    title_subtext_y = title_logo_y + len(logo_lines) + 1 if logo_lines else 2
+    title_subtext_y = (
+        title_logo_y + len(logo_lines) + 1 if logo_lines else vertical_offset
+    )
     title_countdown_text = "Starting in    sec."
     title_countdown_x = (40 - len(title_countdown_text)) // 2
     title_countdown_y = title_subtext_y + len(title_subtext_lines) + 1


### PR DESCRIPTION
## Summary
- shift the title screen layout down by two lines by applying a vertical offset
- ensure the default logo text and related subtexts render lower on the screen

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ee96ee28832481c50050965b60c6)