### PR TITLE
Initialize config name table before drawing

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/config_scene.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/config_scene.py
@@ -378,22 +378,10 @@ def build_screen0_config_menu(
         LD.A_n8(block, 0x82)
         OUT(block, 0x99)
 
-        # 2. 画面全体をクリア ($1800〜$1BBF)
-        LD.HL_n16(block, screen0_name_base)
-        SET_VRAM_WRITE_FUNC.call(block)
-        LD.BC_n16(block, 40 * 24)  # 960文字分
-        LD.A_n8(block, 0x20)  # スペースのキャラコード
-        clear_loop = unique_label("__CLEAR_LOOP__")
-        block.label(clear_loop)
-        OUT(block, 0x98)
-        DEC.BC(block)
-        LD.A_B(block)
-        OR.C(block)
-        JR_NZ(block, clear_loop)
-
         set_screen_colors_macro(block, 15, 4, 4, current_screen_mode=0)
 
         # ネームテーブル（$1800〜$1BFF）をスペース（0x20）で埋める
+        # （文字描画前に必ず初期化しておく）
         LD.HL_n16(block, screen0_name_base)
         SET_VRAM_WRITE_FUNC.call(block)
         LD.BC_n16(block, 40 * 24)  # SCREEN 0 全体


### PR DESCRIPTION
## Summary
- ensure the SCREEN 0 config scene clears the name table with spaces before rendering menu text
- remove redundant name-table clearing loop while keeping sprite setup intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957595ed3c48324b213ca6261a47428)