### PR TITLE
Adjust beep defaults and volume control

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
@@ -683,13 +683,17 @@ def build_update_input_func(
 def build_beep_control_utils(
     beep_count_addr: int = 0xC110,
     beep_active_addr: int = 0xC111,
-    tone_period: int = 60,  # 0-4095
+    tone_period: int = 30,  # 0-4095
     duration_frames: int = 1,  # 1/60秒単位
+    volume: int = 8,
     *,
     group: str = DEFAULT_FUNC_GROUP_NAME,
 ):
     PSG_REG = 0xA0
     PSG_DAT = 0xA1
+
+    if not 0 <= volume <= 15:
+        raise ValueError("volume must be between 0 and 15")
 
     def psg_write(block: Block) -> None:
         OUT(block, PSG_REG)
@@ -729,7 +733,7 @@ def build_beep_control_utils(
 
         # 3. 音量設定 (Reg 8)
         LD.A_n8(block, 8)
-        LD.E_n8(block, 15)
+        LD.E_n8(block, volume)
         BEEP_WRITE_FUNC.call(block)
 
         RET(block)


### PR DESCRIPTION
## Summary
- set the default beep tone period to 30
- allow configuring beep volume with validation and apply it when triggering the beep

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69575a272ee08324ad139adbf4a80d07)