### PR TITLE
Fix SCREEN 0 config sprite attribute placement

### DIFF
--- a/pyutils/mmsxxasmhelper/examples/config_scene_screen0_demo.py
+++ b/pyutils/mmsxxasmhelper/examples/config_scene_screen0_demo.py
@@ -50,7 +50,6 @@ def build_config_scene_rom() -> bytes:
         work_base_addr=0xC220,
         screen0_name_base=0x1800,
         sprite_pattern_addr=0x3800,
-        sprite_attribute_addr=0x1B00,
     )
 
     # 0x00 終端文字列を CHPUT で描画


### PR DESCRIPTION
## Summary
- compute a safe default sprite attribute table address for SCREEN0 config menus and guard against overlap with the name table
- update the SCREEN0 config demo to rely on the safer defaults

## Testing
- python -m pytest tests/test_screen0_config_menu.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69577a9367908324abf3f331729952d4)