### PR TITLE
Add macro to embed debug strings safely

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
@@ -17,6 +17,7 @@ __all__ = [
     "set_debug",
     "debug_trap",
     "debug_print_labels",
+    "embed_debug_string_macro",
     "print_bytes",
     "MemAddrAllocator",
     "with_register_preserve",
@@ -182,6 +183,24 @@ def debug_trap(b: Block) -> None:
     if not DEBUG:
         return
     HALT(b)
+
+
+#
+# デバッグ用に任意の文字列を埋め込む
+#
+
+def embed_debug_string_macro(b: Block, text: str, *, encoding: str = "ascii") -> None:
+    """任意の文字列をコードに埋め込むデバッグマクロ。
+
+    文字列の直前に文字列終端へのジャンプを挿入するため、
+    任意の位置に配置しても実行フローへ影響を与えない。
+    デバッグ時のメモリダンプで位置を把握しやすくする用途を想定している。
+    """
+
+    end_label = unique_label("debugstr_end")
+    JP(b, end_label)
+    DB(b, *str_bytes(text, encoding))
+    b.label(end_label)
 
 
 #

--- a/tests/test_embed_debug_string_macro.py
+++ b/tests/test_embed_debug_string_macro.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+
+# Make assembler helper importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "pyutils/mmsxxasmhelper/src"))
+
+from mmsxxasmhelper.core import Block, NOP  # noqa: E402
+from mmsxxasmhelper import utils  # noqa: E402
+
+
+def test_embed_debug_string_macro_skips_embedded_bytes():
+    b = Block()
+
+    utils.embed_debug_string_macro(b, "HERE")
+    NOP(b)
+
+    rom = b.finalize()
+
+    # JP should skip past the embedded string
+    jump_target = int.from_bytes(rom[1:3], byteorder="little")
+    assert jump_target == 3 + len("HERE")
+
+    # The string bytes should be present immediately after the JP
+    assert rom[3:3 + len("HERE")] == b"HERE"
+
+    # Execution resumes at the instruction after the embedded string
+    assert rom[jump_target] == 0x00  # NOP opcode


### PR DESCRIPTION
## Summary
- add a macro that embeds a debug string while skipping over it to avoid affecting execution
- document the new utility in the assembler helper exports
- add a unit test that verifies the embedded string bytes and jump target

## Testing
- python -m pytest tests/test_embed_debug_string_macro.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594e2cbdbc8324975f775633af5722)