### PR TITLE
Report embedded debug string locations after finalize

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -133,6 +133,7 @@ class Block:
         self.pc: int = 0
         self.labels: Dict[str, int] = {}
         self.fixups: List[Fixup] = []
+        self._finalize_callbacks: List[Callable[["Block", int], None]] = []
 
     # --- 基本出力 ---
 
@@ -210,6 +211,9 @@ class Block:
                 self.code[fx.pos] = offset & 0xFF
             else:
                 raise ValueError(f"unknown fixup kind: {fx.kind}")
+
+        for callback in self._finalize_callbacks:
+            callback(self, origin)
 
         return bytes(self.code)
 

--- a/tests/test_embed_debug_string_macro.py
+++ b/tests/test_embed_debug_string_macro.py
@@ -25,3 +25,19 @@ def test_embed_debug_string_macro_skips_embedded_bytes():
 
     # Execution resumes at the instruction after the embedded string
     assert rom[jump_target] == 0x00  # NOP opcode
+
+
+def test_embed_debug_string_macro_reports_locations(capsys):
+    b = Block()
+
+    utils.embed_debug_string_macro(b, "HERE")
+    utils.embed_debug_string_macro(b, "THERE")
+    NOP(b)
+
+    b.finalize(origin=0x4000)
+
+    output = capsys.readouterr().out.splitlines()
+
+    assert output[0] == "Embedded debug strings:"
+    assert "4003 (+0003): HERE" in output[1]
+    assert "400A (+000A): THERE" in output[2]


### PR DESCRIPTION
## Summary
- add finalize callbacks to Block for post-processing steps
- track embedded debug strings and report their ROM addresses after finalization
- cover debug string reporting with new unit test

## Testing
- python -m pytest tests/test_embed_debug_string_macro.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594ff74bb08324b1acba375b03a757)