### PR TITLE
Add NOP padding around embedded debug strings

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
@@ -199,9 +199,11 @@ def embed_debug_string_macro(b: Block, text: str, *, encoding: str = "ascii") ->
 
     end_label = unique_label("debugstr_end")
     JP(b, end_label)
+    NOP(b)
     string_pos = b.pc
     string_bytes = str_bytes(text, encoding)
     DB(b, *string_bytes)
+    NOP(b)
     b.label(end_label)
 
     _register_debug_string(b, text, string_pos)

--- a/tests/test_embed_debug_string_macro.py
+++ b/tests/test_embed_debug_string_macro.py
@@ -18,13 +18,14 @@ def test_embed_debug_string_macro_skips_embedded_bytes():
 
     # JP should skip past the embedded string
     jump_target = int.from_bytes(rom[1:3], byteorder="little")
-    assert jump_target == 3 + len("HERE")
+    assert jump_target == 3 + 1 + len("HERE") + 1
 
     # The string bytes should be present immediately after the JP
-    assert rom[3:3 + len("HERE")] == b"HERE"
+    assert rom[4:4 + len("HERE")] == b"HERE"
 
     # Execution resumes at the instruction after the embedded string
-    assert rom[jump_target] == 0x00  # NOP opcode
+    assert rom[3] == 0x00  # NOP opcode before the string
+    assert rom[jump_target] == 0x00  # NOP opcode after the string
 
 
 def test_embed_debug_string_macro_reports_locations(capsys):
@@ -39,5 +40,5 @@ def test_embed_debug_string_macro_reports_locations(capsys):
     output = capsys.readouterr().out.splitlines()
 
     assert output[0] == "Embedded debug strings:"
-    assert "4003 (+0003): HERE" in output[1]
-    assert "400A (+000A): THERE" in output[2]
+    assert "4004 (+0004): HERE" in output[1]
+    assert "400D (+000D): THERE" in output[2]


### PR DESCRIPTION
## Summary
- add NOP instructions before and after embedded debug strings to keep disassembly aligned
- update debug string offset tracking and tests to match the new layout

## Testing
- python -m pytest tests/test_embed_debug_string_macro.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69595317c7248324adf773aee107ec73)