### PR TITLE
Fix debug label test import path

### DIFF
--- a/tests/test_debug_labels.py
+++ b/tests/test_debug_labels.py
@@ -13,10 +13,14 @@ from __future__ import annotations
 import importlib
 import sys
 import types
+from pathlib import Path
 
 
 def _import_create_scroll_megarom(monkeypatch):
     """Import the ROM builder with minimal stubs for optional dependencies."""
+
+    # Ensure the repository root is importable when tests run from the tests directory.
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1]))
 
     # The assembler helper lives in the repository; make it importable.
     monkeypatch.syspath_prepend("pyutils/mmsxxasmhelper/src")


### PR DESCRIPTION
## Summary
- ensure debug label test prepends the repository root to sys.path before importing the ROM builder

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695953f237ac83249625f8143af0d960)