### PR TITLE
Add address range output for embedded debug strings

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py
@@ -206,16 +206,16 @@ def embed_debug_string_macro(b: Block, text: str, *, encoding: str = "ascii") ->
     NOP(b)
     b.label(end_label)
 
-    _register_debug_string(b, text, string_pos)
+    _register_debug_string(b, text, string_pos, len(string_bytes))
 
 
-def _register_debug_string(b: Block, text: str, offset: int) -> None:
+def _register_debug_string(b: Block, text: str, offset: int, length: int) -> None:
     entries = getattr(b, "_embedded_debug_strings", None)
     if entries is None:
         entries = []
         setattr(b, "_embedded_debug_strings", entries)
 
-    entries.append((text, offset))
+    entries.append((text, offset, length))
 
     if getattr(b, "_embedded_debug_strings_registered", False):
         return
@@ -229,9 +229,14 @@ def _register_debug_string(b: Block, text: str, offset: int) -> None:
             return
 
         print("Embedded debug strings:")
-        for string, relative_offset in embedded:
-            absolute = origin + relative_offset
-            print(f"  {absolute:04X} (+{relative_offset:04X}): {string}")
+        for string, relative_offset, length in embedded:
+            relative_end = relative_offset + max(length - 1, 0)
+            absolute_start = origin + relative_offset
+            absolute_end = origin + relative_end
+            print(
+                f"  {absolute_start:04X} ~ {absolute_end:04X} "
+                f"(+{relative_offset:04X} ~ +{relative_end:04X}): {string}"
+            )
 
     b._finalize_callbacks.append(_print_debug_strings)
     setattr(b, "_embedded_debug_strings_registered", True)

--- a/tests/test_embed_debug_string_macro.py
+++ b/tests/test_embed_debug_string_macro.py
@@ -40,5 +40,5 @@ def test_embed_debug_string_macro_reports_locations(capsys):
     output = capsys.readouterr().out.splitlines()
 
     assert output[0] == "Embedded debug strings:"
-    assert "4004 (+0004): HERE" in output[1]
-    assert "400D (+000D): THERE" in output[2]
+    assert "4004 ~ 4007 (+0004 ~ +0007): HERE" in output[1]
+    assert "400D ~ 4011 (+000D ~ +0011): THERE" in output[2]


### PR DESCRIPTION
## Summary
- include byte lengths when registering embedded debug strings and report both start and end addresses
- update tests to reflect range-based debug output format

## Testing
- pytest tests/test_embed_debug_string_macro.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695955c16bc4832489a0ef5dce953734)