### PR TITLE
Avoid lambda usage when building draw option funcs

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/config_scene.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/config_scene.py
@@ -240,16 +240,19 @@ def build_screen0_config_menu(
     # ディスパッチ処理で参照できるようにする。ラムダでエントリ情報を束縛し、
     # 個々の描画コード生成を遅延実行する設計。
     draw_option_funcs: list[Func] = []
+    def _create_draw_option_func(
+        func_name: str, entry: Screen0ConfigEntry, entry_index: int, option_width: int
+    ) -> Func:
+        def draw_option(block: Block) -> None:
+            _emit_draw_option(block, entry, entry_index, option_width)
+
+        return Func(func_name, draw_option, group=group)
+
     for idx, entry in enumerate(config_entries):
         option_width = option_field_widths[idx]
+        func_name = f"DRAW_OPTION_{idx}"
         draw_option_funcs.append(
-            Func(
-                f"DRAW_OPTION_{idx}",
-                lambda b, e=entry, i=idx, w=option_width: _emit_draw_option(
-                    b, e, i, w
-                ),
-                group=group,
-            )
+            _create_draw_option_func(func_name, entry, idx, option_width)
         )
 
     def draw_option_dispatch(block: Block) -> None:


### PR DESCRIPTION
## Summary
- replace lambda-based draw option function creation with a helper factory
- preserve bound entry metadata while avoiding inline lambdas

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3992bc8c832487de4cfad4f88e39)