### PR TITLE
Fix config menu option redraw after left/right input

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/config_scene.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/config_scene.py
@@ -515,6 +515,7 @@ def build_screen0_config_menu(
         LD.mn16_A(block, CURRENT_ENTRY_ADDR)
 
         # 値の描画とカーソル形状を再描画する。
+        LD.A_C(block)
         DRAW_OPTION_DISPATCH.call(block)  # JP DRAW_OPTION_{index=a}
         UPDATE_TRIANGLE_FUNC.call(block)
         block.label(LABEL_ADJUST_END)  # __ADJUST_END__


### PR DESCRIPTION
## Summary
- ensure option redraws use the current entry index when changing option values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a6586a5ec8324aa9f06de703a09b4)