### PR TITLE
Adjust unique label numbering per prefix

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -85,7 +85,6 @@ __all__ = [
 ]
 
 from dataclasses import dataclass
-from itertools import count
 from typing import Callable, Dict, List, Literal, Optional, TextIO
 
 
@@ -93,7 +92,7 @@ from typing import Callable, Dict, List, Literal, Optional, TextIO
 # Block: コード構築の基本単位
 # ---------------------------------------------------------------------------
 
-_label_counter = count()
+_label_counters: Dict[str, int] = {}
 DEFAULT_FUNC_GROUP_NAME = "default"
 _created_funcs: Dict[str, "Func"] = {}
 _created_funcs_by_group: Dict[str, List["Func"]] = {}
@@ -102,11 +101,14 @@ _created_funcs_by_group: Dict[str, List["Func"]] = {}
 def unique_label(prefix: str = "__L") -> str:
     """衝突しないラベル名を生成するヘルパー。
 
-    マクロ内など同じラベル名を繰り返し使う状況で、
-    呼ぶたびにユニークな名前を得るために利用する。
+    プレフィックスごとにインデックスを持ち、最初の呼び出しでは
+    インデックスなしのラベル名を返す。以降は ``"{prefix}-<n>"``
+    の形式で連番を付与する。
     """
 
-    return f"{prefix}-{next(_label_counter)}"
+    index = _label_counters.get(prefix, 0)
+    _label_counters[prefix] = index + 1
+    return prefix if index == 0 else f"{prefix}-{index}"
 
 FixupKind = Literal["abs16", "rel8"]  # v0では絶対16bitアドレスと相対8bitのみ扱う
 

--- a/tests/test_unique_label.py
+++ b/tests/test_unique_label.py
@@ -1,4 +1,3 @@
-from itertools import count
 from pathlib import Path
 import sys
 
@@ -8,17 +7,30 @@ import mmsxxasmhelper.core as core
 
 
 def test_unique_label_increments(monkeypatch):
-    monkeypatch.setattr(core, "_label_counter", count(), raising=False)
+    monkeypatch.setattr(core, "_label_counters", {}, raising=False)
 
     first = core.unique_label()
     second = core.unique_label()
 
-    assert first == "__L-0"
+    assert first == "__L"
     assert second == "__L-1"
     assert first != second
 
 
 def test_unique_label_with_custom_prefix(monkeypatch):
-    monkeypatch.setattr(core, "_label_counter", count(), raising=False)
+    monkeypatch.setattr(core, "_label_counters", {}, raising=False)
 
-    assert core.unique_label("__MACRO__") == "__MACRO__-0"
+    assert core.unique_label("__MACRO__") == "__MACRO__"
+    assert core.unique_label("__MACRO__") == "__MACRO__-1"
+
+
+def test_unique_label_isolated_per_prefix(monkeypatch):
+    monkeypatch.setattr(core, "_label_counters", {}, raising=False)
+
+    first_prefix_a = core.unique_label("LABEL_A")
+    first_prefix_b = core.unique_label("LABEL_B")
+    second_prefix_a = core.unique_label("LABEL_A")
+
+    assert first_prefix_a == "LABEL_A"
+    assert first_prefix_b == "LABEL_B"
+    assert second_prefix_a == "LABEL_A-1"


### PR DESCRIPTION
## Summary
- adjust unique_label to keep separate counters per prefix and drop the initial numeric suffix
- update unique_label tests to reflect per-prefix numbering and first-use behavior

## Testing
- pytest tests/test_unique_label.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a9a67c7248324a64d979c3b5ae6cc)