### PR TITLE
Remove unnecessary allocator init defaults

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -222,7 +222,10 @@ class ADDR:
         "AUTO_ADVANCE_COUNTER", 2, description="自動切り替えまでの残りフレーム"
     )
     CONFIG_WORK_BASE = madd(
-        "CONFIG_WORK_BASE", get_work_byte_length_for_screen0_config_menu(), description="コンフィグ用ワークベース")
+        "CONFIG_WORK_BASE",
+        get_work_byte_length_for_screen0_config_menu(),
+        description="コンフィグ用ワークベース",
+    )
 
 # mem_addr_allocator.debug_print()
 
@@ -1035,11 +1038,7 @@ def build_boot_bank(
     enaslt_macro(b)
 
     # コンフィグの初期値を設定
-    # XOR.A(b)
-    # LD.mn16_A(b, ADDR.CONFIG_AUTO_SPEED)
-    # LD.mn16_A(b, ADDR.AUTO_ADVANCE_COUNTER)
-    # LD.mn16_A(b, ADDR.CONFIG_WORK_BASE)
-    # LD.mn16_A(b, ADDR.CONFIG_AUTO_SCROLL)
+    mem_addr_allocator.emit_initial_value_loader(b)
     if beep_enabled_default:
         LD.mn16_A(b, ADDR.CONFIG_BEEP_ENABLED)
     else:


### PR DESCRIPTION
## Summary
- stop marking AUTO_ADVANCE_COUNTER and CONFIG_WORK_BASE with explicit initial values since RAM defaults to zero
- keep allocator initialization helper focused on entries that require non-zero defaults

## Testing
- python -m compileall pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py pyutils/sc2_viewer_rom/src/create_scroll_megarom.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af64b31f08324add0e29d6213ca2c)