### PR TITLE
Fix dump_regs byte order for AF high-low output

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -2678,13 +2678,28 @@ def dump_regs(
         PUSH.r(b, reg)
         push_sequence.append(reg)
 
-    # スタック先頭→dest_addr に LDIR でコピー
+    # スタック先頭→dest_addr に AF の上位バイトから順にコピー
     LD.HL_n16(b, 0)
     ADD.HL_SP(b)
     LD.DE_n16(b, dest_addr & 0xFFFF)
     if total_bytes:
-        LD.BC_n16(b, total_bytes)
-        LDIR(b)
+        for idx in range(len(selected)):
+            # 上位バイト
+            INC.HL(b)
+            LD.A_mHL(b)
+            LD.mDE_A(b)
+            INC.DE(b)
+
+            # 下位バイト
+            DEC.HL(b)
+            LD.A_mHL(b)
+            LD.mDE_A(b)
+            INC.DE(b)
+
+            # 次のレジスタへ
+            if idx + 1 < len(selected):
+                INC.HL(b)
+                INC.HL(b)
 
     if padding:
         XOR.A(b)

--- a/tests/test_dump_regs.py
+++ b/tests/test_dump_regs.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "pyutils/mmsxxasmhelper/src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "pyutils/mmsxxasmhelper/src"))
 
 from mmsxxasmhelper.core import Block, dump_regs, register_dump_target
 
@@ -26,11 +26,44 @@ def test_dump_regs_default_sequence():
             0x11,
             0x00,
             0x40,  # LD DE,0x4000
-            0x01,
-            0x08,
-            0x00,  # LD BC,8
-            0xED,
-            0xB0,  # LDIR
+            0x23,
+            0x7E,
+            0x12,
+            0x13,
+            0x2B,
+            0x7E,
+            0x12,
+            0x13,
+            0x23,
+            0x23,
+            0x23,
+            0x7E,
+            0x12,
+            0x13,
+            0x2B,
+            0x7E,
+            0x12,
+            0x13,
+            0x23,
+            0x23,
+            0x23,
+            0x7E,
+            0x12,
+            0x13,
+            0x2B,
+            0x7E,
+            0x12,
+            0x13,
+            0x23,
+            0x23,
+            0x23,
+            0x7E,
+            0x12,
+            0x13,
+            0x2B,
+            0x7E,
+            0x12,
+            0x13,
             0xF1,  # POP AF
             0xC1,  # POP BC
             0xD1,  # POP DE
@@ -57,11 +90,14 @@ def test_dump_regs_padding_and_selection():
             0x11,
             0x34,
             0x12,  # LD DE,0x1234
-            0x01,
-            0x02,
-            0x00,  # LD BC,2
-            0xED,
-            0xB0,  # LDIR
+            0x23,
+            0x7E,
+            0x12,
+            0x13,
+            0x2B,
+            0x7E,
+            0x12,
+            0x13,
             0xAF,  # XOR A -> A=0
             0x12,
             0x13,


### PR DESCRIPTION
## Summary
- update dump_regs to copy register pairs with the high byte first so AF dumps as expected
- adjust dump_regs tests to load the local source tree and reflect the new copy instructions

## Testing
- pytest tests/test_dump_regs.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d3fa294048324947322ba714158fc)