### PR TITLE
Fix scroll viewer target row banking

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -216,7 +216,7 @@ class ADDR:
 
     PG_BUFFER = madd("PG_BUFFER", 256 * 3)
     CT_BUFFER = madd("CT_BUFFER", 256 * 3)
-    TARGET_ROW = madd("TARGET_ROW", 1)  # 更新する画像上の行番号
+    TARGET_ROW = madd("TARGET_ROW", 2)  # 更新する画像上の行番号 (16bit)
     VRAM_ROW_OFFSET = madd("VRAM_ROW_OFFSET", 1)  # VRAMブロック内の0-7行目オフセット
     CONFIG_BEEP_ENABLED = madd(
         "CONFIG_BEEP_ENABLED", 1, description="BEEPの有効/無効"
@@ -764,10 +764,16 @@ def build_sync_scroll_row_func(*, group: str = DEFAULT_FUNC_GROUP_NAME) -> Func:
         # --- ① パターン (PG) 転送準備 ---
         # 行番号から2bit分を切り出してパターンバンク番号として使い、
         # タイルデータが格納されているROMバンクをページ2に接続する。
-        LD.A_mn16(block, ADDR.TARGET_ROW)  # パターンジェネレータデータだけが1画面を超えてもならぶためバンク番号差分がわかる
+        LD.HL_mn16(block, ADDR.TARGET_ROW)
+        LD.A_H(block)
+        ADD.A_A(block)
+        ADD.A_A(block)  # A = row_high * 4 (256行ごとに4バンク進む)
+        LD.C_A(block)
+        LD.A_L(block)  # パターンジェネレータデータだけが1画面を超えてもならぶためバンク番号差分がわかる
         RLCA(block)
         RLCA(block)
         AND.n8(block, 0x03)
+        ADD.A_C(block)
         LD.C_A(block)
         LD.A_mn16(block, ADDR.CURRENT_IMAGE_START_BANK_ADDR)  # 今のバンク番号に加算
         ADD.A_C(block)
@@ -775,7 +781,8 @@ def build_sync_scroll_row_func(*, group: str = DEFAULT_FUNC_GROUP_NAME) -> Func:
         LD.B_A(block)  # B = バンク番号 保存
 
         # VRAM側で参照する行の開始アドレス(HL)を組み立てておく。
-        LD.A_mn16(block, ADDR.TARGET_ROW)
+        LD.HL_mn16(block, ADDR.TARGET_ROW)
+        LD.A_L(block)
         AND.n8(block, 0x3F)  # 0b00111111 (行番号下位6bit)  この処理必要？？？
         ADD.A_n8(block, 0x80)
         LD.H_A(block)
@@ -789,15 +796,23 @@ def build_sync_scroll_row_func(*, group: str = DEFAULT_FUNC_GROUP_NAME) -> Func:
         # 0/8/16 ライン先頭を PG_BUFFER に連続配置する。
         for idx, line_offset in enumerate([0, 8, 16]):
             # 行番号にオフセットを加味し、対象バンクを決定。
-            LD.A_mn16(block, ADDR.TARGET_ROW)
+            LD.HL_mn16(block, ADDR.TARGET_ROW)
             if line_offset:
-                ADD.A_n8(block, line_offset)
-            LD.D_A(block)  # 後続のアドレス計算用に保持
+                LD.BC_n16(block, line_offset)
+                ADD.HL_BC(block)
+            LD.D_H(block)  # 後続のアドレス計算用に保持
+            LD.E_L(block)
 
+            LD.A_D(block)
+            ADD.A_A(block)
+            ADD.A_A(block)  # A = row_high * 4
+            LD.C_A(block)
+            LD.A_E(block)
             RLCA(block)
             RLCA(block)
             AND.n8(block, 0x03)
-            LD.C_A(block)  # バンク番号の下位2bit
+            ADD.A_C(block)
+            LD.C_A(block)  # バンク番号の下位2bit + high
 
             LD.A_mn16(block, ADDR.CURRENT_IMAGE_START_BANK_ADDR)
             ADD.A_C(block)
@@ -805,7 +820,7 @@ def build_sync_scroll_row_func(*, group: str = DEFAULT_FUNC_GROUP_NAME) -> Func:
             LD.E_A(block)  # E = バンク番号 (コピー中の境界越え検出用)
 
             # HL = パターン開始アドレス
-            LD.A_D(block)
+            LD.A_E(block)
             AND.n8(block, 0x3F)
             ADD.A_n8(block, 0x80)
             LD.H_A(block)
@@ -839,19 +854,21 @@ def build_sync_scroll_row_func(*, group: str = DEFAULT_FUNC_GROUP_NAME) -> Func:
         # パターンと同様に、表示行に対応するカラー定義を 0/8/16 ライン先頭で
         # まとめて読み込み、後段での VRAM 転送に備えておく。
         for idx, line_offset in enumerate([0, 8, 16]):
-            LD.A_mn16(block, ADDR.TARGET_ROW)
+            LD.HL_mn16(block, ADDR.TARGET_ROW)
             if line_offset:
-                ADD.A_n8(block, line_offset)
-            LD.D_A(block)
+                LD.BC_n16(block, line_offset)
+                ADD.HL_BC(block)
+            LD.D_H(block)
+            LD.E_L(block)
 
             # カラーデータのバンクを初期化
             LD.A_mn16(block, ADDR.CURRENT_IMAGE_COLOR_BANK_ADDR)
             LD.E_A(block)
 
             # HL = カラー開始アドレス
-            LD.A_D(block)
+            LD.A_E(block)
             LD.L_A(block)
-            LD.H_n8(block, 0)
+            LD.H_D(block)
             LD.A_mn16(block, ADDR.CURRENT_IMAGE_COLOR_ADDRESS_ADDR + 1)
             ADD.A_L(block)
             LD.H_A(block)
@@ -1197,8 +1214,7 @@ def build_boot_bank(
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
 
     # ターゲット行は「新しく入ってきた上端の行」
-    LD.A_L(b)
-    LD.mn16_A(b, ADDR.TARGET_ROW)
+    LD.mn16_HL(b, ADDR.TARGET_ROW)
     JR(b, "DO_UPDATE_SCROLL")
 
     b.label("CHECK_DOWN")
@@ -1269,8 +1285,7 @@ def build_boot_bank(
     # ターゲット行は「新しく入ってきた下端の行 (開始行 + 23)」
     LD.BC_n16(b, 23)
     ADD.HL_BC(b)
-    LD.A_L(b)
-    LD.mn16_A(b, ADDR.TARGET_ROW)
+    LD.mn16_HL(b, ADDR.TARGET_ROW)
 
     b.label("DO_UPDATE_SCROLL")
     # 1. 新しい行の PG/CT を転送  ADDR,TARGET_ROW に行番号が入っている


### PR DESCRIPTION
## Summary
- store scroll viewer target row as a 16-bit value so bank calculations preserve high bits
- update sync-scroll routines to compute ROM bank offsets and addresses using full row numbers, including offsets
- write target rows with 16-bit stores during incremental scroll updates

## Testing
- pytest -q (fails: existing test expectations unrelated to this change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d76754824832492f5ecdb908e2205)