### PR TITLE
Add turboR high speed helper

### DIFF
--- a/pyutils/mmsxxasmhelper/examples/msx_version_screen0_demo.py
+++ b/pyutils/mmsxxasmhelper/examples/msx_version_screen0_demo.py
@@ -19,6 +19,7 @@ from mmsxxasmhelper.msxutils import (
     BDRCLR,
     FORCLR,
     CHGCLR,
+    enable_turbor_high_speed_macro,
     enaslt_macro,
     get_msxver_macro,
     place_msx_rom_header_macro,
@@ -58,6 +59,7 @@ def build_msx_version_rom() -> bytes:
     # スタックポインタ退避＋スロット有効化
     store_stack_pointer_macro(b)
     enaslt_macro(b)
+    enable_turbor_high_speed_macro(b)
 
     # SCREEN 0 を初期化して見やすい色をセット
     CALL(b, INITXT)


### PR DESCRIPTION
## Summary
- add a helper macro that switches turboR machines into R800 DRAM high-speed mode automatically
- expose the macro alongside the other MSX utilities and use it in the version demo ROM

## Testing
- python -m compileall pyutils/mmsxxasmhelper/src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8199307083249df4e91ac80ae93d)