### PR TITLE
SRL 命令ヘルパを追加

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py
@@ -75,6 +75,7 @@ __all__ = [
     "LD", "ADD", "ADC", "SUB", "SBC", "CP", "AND", "OR", "XOR", "BIT",
     "EX",
     "CPL", "NEG",
+    "SRL",
     "LDI", "LDD", "LDIR",
     "RLCA",
     "INC", "DEC",
@@ -2177,6 +2178,78 @@ def RRA(b: Block) -> None:
     b.emit(0x1F)
 
 
+class SRL:
+    """SRL r/(HL)/(IX+d)/(IY+d) 命令。"""
+
+    _REG8_INDEX = {
+        "B": 0,
+        "C": 1,
+        "D": 2,
+        "E": 3,
+        "H": 4,
+        "L": 5,
+        "mHL": 6,
+        "A": 7,
+    }
+
+    @staticmethod
+    def r(b: Block, reg: str) -> None:
+        """SRL reg"""
+
+        try:
+            r_index = SRL._REG8_INDEX[reg]
+        except KeyError as exc:
+            raise ValueError(f"invalid SRL reg operand: {reg}") from exc
+        opcode = 0x38 | r_index
+        b.emit(0xCB, opcode)
+
+    @staticmethod
+    def B(b: Block) -> None:
+        SRL.r(b, "B")
+
+    @staticmethod
+    def C(b: Block) -> None:
+        SRL.r(b, "C")
+
+    @staticmethod
+    def D(b: Block) -> None:
+        SRL.r(b, "D")
+
+    @staticmethod
+    def E(b: Block) -> None:
+        SRL.r(b, "E")
+
+    @staticmethod
+    def H(b: Block) -> None:
+        SRL.r(b, "H")
+
+    @staticmethod
+    def L(b: Block) -> None:
+        SRL.r(b, "L")
+
+    @staticmethod
+    def A(b: Block) -> None:
+        SRL.r(b, "A")
+
+    @staticmethod
+    def mHL(b: Block) -> None:
+        SRL.r(b, "mHL")
+
+    @staticmethod
+    def mIXd(b: Block, disp: int) -> None:
+        """SRL (IX+d)"""
+
+        opcode = 0x38 | SRL._REG8_INDEX["mHL"]
+        b.emit(0xDD, 0xCB, disp & 0xFF, opcode)
+
+    @staticmethod
+    def mIYd(b: Block, disp: int) -> None:
+        """SRL (IY+d)"""
+
+        opcode = 0x38 | SRL._REG8_INDEX["mHL"]
+        b.emit(0xFD, 0xCB, disp & 0xFF, opcode)
+
+
 def DAA(b: Block) -> None:
     b.emit(0x27)
 
@@ -2794,4 +2867,3 @@ def dump_mem(
     POP.DE(b)
     POP.BC(b)
     POP.AF(b)
-


### PR DESCRIPTION
### Motivation
- Z80 の論理右シフト命令 `SRL` を Python API から使えるようにするための実装を追加しました。
- 既存のビット操作群と同様にレジスタ版・メモリ版・`IX/IY` インデックス版が必要だったためです。

### Description
- `pyutils/mmsxxasmhelper/src/mmsxxasmhelper/core.py` に `SRL` クラスを追加し、公開 API (`__all__`) に `SRL` を追加しました。
- レジスタ版は `SRL.r` と各レジスタ向けヘルパ（`B/C/D/E/H/L/A`）を実装し、不正なレジスタ指定で `ValueError` を投げます。
- `(HL)` 用の `mHL` とインデックス付きメモリアクセスの `mIXd` / `mIYd` を実装し、オペコードは `0xCB` プレフィックス + `(0x38 | r_index)`、`IX/IY` は `0xDD/0xFD, 0xCB, disp, opcode` を出力します。

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e3454932c832495c5f576d7527dc3)