### PR TITLE
MemAddrAllocator.add から debug_only オプションを削除

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -244,9 +244,8 @@ class ADDR:
         1,
         description="Padding",
     )
-    # debug_only = Trueがまだうまく動いていない
-    DEBUG_DUMP_8BYTE_1 = madd("DEBUG_DUMP_8BYTE_1", 8, description="デバッグ用8バイトダンプ", debug_only=False)
-    DEBUG_DUMP_8BYTE_2 = madd("DEBUG_DUMP_8BYTE_2", 8, description="デバッグ用8バイトダンプ", debug_only=False)
+    DEBUG_DUMP_8BYTE_1 = madd("DEBUG_DUMP_8BYTE_1", 8, description="デバッグ用8バイトダンプ")
+    DEBUG_DUMP_8BYTE_2 = madd("DEBUG_DUMP_8BYTE_2", 8, description="デバッグ用8バイトダンプ")
 
 
 register_dump_target("DEBUG_DUMP_8BYTE_1", ADDR.DEBUG_DUMP_8BYTE_1, 8)

--- a/tests/test_mem_addr_allocator.py
+++ b/tests/test_mem_addr_allocator.py
@@ -104,28 +104,3 @@ def test_lookup_contains_metadata_and_debug_output() -> None:
     assert "[01] 07002h: FLAG (size=1) # flag" in debug_str
 
 
-def test_debug_allocation_is_ignored_when_disabled() -> None:
-    allocator = MemAddrAllocator(0x8000)
-
-    allocator.add("DEBUG", 2, initial_value=b"\xAA\xBB", debug_only=True)
-    allocator.add("NEXT", 1)
-
-    assert allocator.get("DEBUG") == 0x8000
-    assert allocator.get("NEXT") == 0x8000
-    assert allocator.total_size == 1
-    assert allocator.initial_bytes[: allocator.total_size] == bytes([0x00])
-
-
-def test_debug_allocation_is_applied_when_enabled() -> None:
-    allocator = MemAddrAllocator(0x9000, debug=True)
-
-    allocator.add("DEBUG", 2, initial_value=b"\xAA\xBB", debug_only=True)
-    allocator.add("NEXT", 1)
-
-    assert allocator.get("DEBUG") == 0x9000
-    assert allocator.get("NEXT") == 0x9002
-    assert allocator.total_size == 3
-
-    expected = bytes([0xAA, 0xBB, 0x00])
-    assert allocator.initial_bytes[: allocator.total_size] == expected
-


### PR DESCRIPTION
### Motivation
- `MemAddrAllocator.add` の `debug_only` 処理が複雑でバグ（アドレス重複の懸念）を生んでいるため、仕組みを廃止して単純化するための変更です。 
- 呼び出し側でも `debug_only` を渡す箇所があり、整合性のためまとめて修正します。 

### Description
- `MemAddrAllocator.add` のシグネチャから `debug_only` 引数を削除し、割り当ては常に要求された `size` で行うようにしました（未指定時は `initial_value` 長から推論）。
- `debug_only` に依存した条件分岐を削除し、常に初期バイト領域に対してサイズ分の領域を確保して初期値を書き込むようにしました。
- 呼び出し側のコード `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` の `madd(...)` 呼び出しから `debug_only` 指定を除去しました。
- テスト `tests/test_mem_addr_allocator.py` の `debug_only` に依存するケースを削除してテストを整理しました。

### Testing
- 自動テストは実行していません（今回の変更はロジック/呼び出し元/テストの修正を伴うため、CIでの実行を推奨します）。
- 変更対象ファイル: `pyutils/mmsxxasmhelper/src/mmsxxasmhelper/utils.py`, `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py`, `tests/test_mem_addr_allocator.py`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e413f24d883249ead8c898388825e)