### PR TITLE
BGMが16KBを超える場合は先頭16KBに切り詰めて扱うように変更

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1635,7 +1635,7 @@ def build(
     bgm_start_bank: int | None = None
     if bgm_data is not None:
         if len(bgm_data) > PAGE_SIZE:
-            raise ValueError("bgm_data must fit within 16KB")
+            bgm_data = bgm_data[:PAGE_SIZE]
         bgm_start_bank = next_bank
         bgm_payload = bytearray([fill_byte] * PAGE_SIZE)
         bgm_payload[: len(bgm_data)] = bgm_data
@@ -1919,7 +1919,8 @@ def main() -> None:
             raise SystemExit(f"BGM file not found: {args.bgm_path}")
         bgm_data = args.bgm_path.read_bytes()
         if len(bgm_data) > PAGE_SIZE:
-            raise SystemExit("BGM file size exceeds 16KB")
+            log_and_store("BGM file size exceeds 16KB; truncating to 16KB", log_lines)
+            bgm_data = bgm_data[:PAGE_SIZE]
 
     rom = build(
         image_data_list,


### PR DESCRIPTION
### Motivation
- BGMファイルが16KBを超えるとエラー／終了してしまうため、大きめのBGMを扱う際に処理できるようにする意図です。 
- CLI実行時にユーザーに切り詰めを通知して処理を継続できるようにしたい意図です。 

### Description
- `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` の `build` 内で `bgm_data` が `PAGE_SIZE`（16KB）を超える場合に `ValueError` を投げる代わりに先頭 `PAGE_SIZE` バイトへ切り詰めるように変更しました（`bgm_data = bgm_data[:PAGE_SIZE]`）。
- `main` の BGM読み込み箇所でファイルサイズ超過時に `SystemExit` で終了するのではなく、`log_and_store` で切り詰めをログ出力してから先頭 `PAGE_SIZE` バイトに切り詰めるように変更しました。 

### Testing
- 自動化されたテストは実行していません。 
- 変更は該当ファイルのロジック修正のみで、既存の処理フローに沿う形で実装しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e4bfbc080832499dcdb39ca649093)