### PR TITLE
PSGバンク復帰を割り込み処理末尾へ移動

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/psgstream.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/psgstream.py
@@ -100,6 +100,8 @@ def build_play_vgm_frame_func(
 
     def music_isr(block: Block) -> None:
         skip_play = unique_label("MUSIC_ISR_SKIP_PLAY")
+        restore_bank = unique_label("MUSIC_ISR_RESTORE_BANK")
+        after_restore = unique_label("MUSIC_ISR_AFTER_RESTORE")
         LD.A_mn16(block, bgm_enabled_addr)
         OR.A(block)
         RET_Z(block)
@@ -125,10 +127,15 @@ def build_play_vgm_frame_func(
                 LD.mn16_A(block, current_bank_addr)
         play_vgm_frame_macro(block)
         if vgm_bank_addr is not None and current_bank_addr is not None:
+            JR(block, restore_bank)
+        block.label(skip_play)
+        if vgm_bank_addr is not None and current_bank_addr is not None:
+            JR(block, after_restore)
+            block.label(restore_bank)
             POP.AF(block)
             LD.mn16_A(block, page2_bank_reg_addr)
             LD.mn16_A(block, current_bank_addr)
-        block.label(skip_play)
+            block.label(after_restore)
 
         POP.IY(block)
         POP.IX(block)


### PR DESCRIPTION
### Motivation
- 割り込み内でPSGのページ切替を行ったあと、再生がスキップされた場合に誤ってバンク復帰処理を行わないようにするため。 
- 復帰処理をISRの末尾に集約し、復帰が必要な場合のみ通る制御フローにしたい。 
- スタック操作と復帰処理の順序を明確にして安全に復帰できるようにする。 

### Description
- `MUSIC_ISR_RESTORE_BANK` と `MUSIC_ISR_AFTER_RESTORE` のラベルを追加して復帰処理をISR末尾へ移動しました。 
- 再生処理後の復帰処理を直接実行するのではなく `JR` ジャンプで末尾の復帰ブロックへ遷移させ、`skip_play` 時は復帰ブロックを通らないよう制御を変更しました。 
- 変更ファイル: `pyutils/mmsxxasmhelper/src/mmsxxasmhelper/psgstream.py` の `music_isr` 実装を修正しました。 

### Testing
- 自動テストは実行していません（未実施）。
- 静的解析やリンターなどの自動チェックも実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e7e0ebe848324b336fff798aba8a4)