### PR TITLE
BGM無効時にPSG出力を停止

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/psgstream.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/psgstream.py
@@ -109,17 +109,17 @@ def build_play_vgm_frame_func(
         OR.A(block)
         JP_NZ(block, process_play)
 
-        # 音量を0にする（うまく動かず消えていない）
+        # PSGを停止（ミキサー無効化 + 各チャンネル音量0）
         LD.A_n8(block, 0x07)
         OUT(block, psg_reg_port)
-        LD.A_n8(block, 0x0b10111111)
+        LD.A_n8(block, 0b10111111)
         OUT(block, psg_data_port)
-        """
-        ld  a, 7            ; レジスタ7 (ミキサー) を指定
-        out (0xa0), a       ; レジスタ選択ポート
-        ld  a, 0b10111111   ; 下位6ビットを1にする (発音禁止)
-        out (0xa1), a       ; データ書き込みポート
-        """
+
+        for reg in (8, 9, 10):
+            LD.A_n8(block, reg)
+            OUT(block, psg_reg_port)
+            LD.A_n8(block, 0)
+            OUT(block, psg_data_port)
 
         RET(block)
 


### PR DESCRIPTION
### Motivation
- `music_isr`でBGMが無効化されたときPSGの音が残ってしまう問題を確実に遮断するために、ミキサー無効化だけでなく各チャンネルの音量レジスタを0にする処理を追加しました。

### Description
- `pyutils/mmsxxasmhelper/src/mmsxxasmhelper/psgstream.py`の`music_isr`でミキサーレジスタ（レジスタ7）に`0b10111111`を書き込む処理を保持しました。
- レジスタ`8`〜`10`をループで選択して音量を`0`に設定するコードを追加しました（各チャンネルの音を確実に停止）。
- コメント化されていた古いアセンブリ例を削除し、バイナリリテラル表記の誤りを修正しました。

### Testing
- 自動テストは実行していません（`not run`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee547cacc83249e2677bf182809d9)