### PR TITLE
`TARGET_ROW` を16bit化してスクロール下方向のズレを修正

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -330,7 +330,7 @@ class ADDR:
 
     PG_BUFFER = madd("PG_BUFFER", 256 * 3)
     CT_BUFFER = madd("CT_BUFFER", 256 * 3)
-    TARGET_ROW = madd("TARGET_ROW", 1)  # 更新する画像上の行番号
+    TARGET_ROW = madd("TARGET_ROW", 2)  # 更新する画像上の行番号
     VRAM_ROW_OFFSET = madd("VRAM_ROW_OFFSET", 1)  # VRAMブロック内の0-7行目オフセット
     CONFIG_BEEP_ENABLED = madd(
         "CONFIG_BEEP_ENABLED", 1, description="BEEPの有効/無効"
@@ -878,10 +878,16 @@ def build_sync_scroll_row_func(*, group: str = DEFAULT_FUNC_GROUP_NAME) -> Func:
         # --- ① パターン (PG) 転送準備 ---
         # 行番号から2bit分を切り出してパターンバンク番号として使い、
         # タイルデータが格納されているROMバンクをページ2に接続する。
-        LD.A_mn16(block, ADDR.TARGET_ROW)  # パターンジェネレータデータだけが1画面を超えてもならぶためバンク番号差分がわかる
+        LD.HL_mn16(block, ADDR.TARGET_ROW)
+        LD.A_H(block)
+        ADD.A_A(block)
+        ADD.A_A(block)
+        LD.C_A(block)
+        LD.A_L(block)  # パターンジェネレータデータだけが1画面を超えてもならぶためバンク番号差分がわかる
         RLCA(block)
         RLCA(block)
         AND.n8(block, 0x03)
+        ADD.A_C(block)
         LD.C_A(block)
         LD.A_mn16(block, ADDR.CURRENT_IMAGE_START_BANK_ADDR)  # 今のバンク番号に加算
         ADD.A_C(block)
@@ -889,7 +895,7 @@ def build_sync_scroll_row_func(*, group: str = DEFAULT_FUNC_GROUP_NAME) -> Func:
         LD.B_A(block)  # B = バンク番号 保存
 
         # VRAM側で参照する行の開始アドレス(HL)を組み立てておく。
-        LD.A_mn16(block, ADDR.TARGET_ROW)
+        LD.A_L(block)
         AND.n8(block, 0x3F)  # 0b00111111 (行番号下位6bit)  この処理必要？？？
         ADD.A_n8(block, 0x80)
         LD.H_A(block)
@@ -900,13 +906,27 @@ def build_sync_scroll_row_func(*, group: str = DEFAULT_FUNC_GROUP_NAME) -> Func:
         # --- カラー (CT) 転送 ---
         # 表示行に対応するカラー定義を 0/8/16 ライン先頭で VRAM へ直接出力する。
         for line_offset in [0, 8, 16]:
-            LD.A_mn16(block, ADDR.TARGET_ROW)
+            LD.HL_mn16(block, ADDR.TARGET_ROW)
             if line_offset:
-                ADD.A_n8(block, line_offset)
+                LD.DE_n16(block, line_offset)
+                ADD.HL_DE(block)
+            LD.A_L(block)
             LD.D_A(block)
+
+            LD.A_H(block)
+            ADD.A_A(block)
+            ADD.A_A(block)
+            LD.C_A(block)
+            LD.A_L(block)
+            RLCA(block)
+            RLCA(block)
+            AND.n8(block, 0x03)
+            ADD.A_C(block)
+            LD.C_A(block)
 
             # カラーデータのバンクを初期化
             LD.A_mn16(block, ADDR.CURRENT_IMAGE_COLOR_BANK_ADDR)
+            ADD.A_C(block)
             LD.E_A(block)
 
             # HL = カラー開始アドレス
@@ -934,7 +954,7 @@ def build_sync_scroll_row_func(*, group: str = DEFAULT_FUNC_GROUP_NAME) -> Func:
             LD.L_n8(block, 0)
 
             PUSH.HL(block)
-            LD.A_mn16(block, ADDR.TARGET_ROW)
+            LD.A_D(block)
             AND.n8(block, 0x07)
             ADD.A_n8(block, 0x20 + line_offset)
             LD.H_A(block)
@@ -952,14 +972,22 @@ def build_sync_scroll_row_func(*, group: str = DEFAULT_FUNC_GROUP_NAME) -> Func:
         # 0/8/16 ライン先頭を VRAM の各ミラー領域へ直接出力する。
         for line_offset in [0, 8, 16]:
             # 行番号にオフセットを加味し、対象バンクを決定。
-            LD.A_mn16(block, ADDR.TARGET_ROW)
+            LD.HL_mn16(block, ADDR.TARGET_ROW)
             if line_offset:
-                ADD.A_n8(block, line_offset)
+                LD.DE_n16(block, line_offset)
+                ADD.HL_DE(block)
+            LD.A_L(block)
             LD.D_A(block)  # 後続のアドレス計算用に保持
 
+            LD.A_H(block)
+            ADD.A_A(block)
+            ADD.A_A(block)
+            LD.C_A(block)
+            LD.A_L(block)
             RLCA(block)
             RLCA(block)
             AND.n8(block, 0x03)
+            ADD.A_C(block)
             LD.C_A(block)  # バンク番号の下位2bit
 
             LD.A_mn16(block, ADDR.CURRENT_IMAGE_START_BANK_ADDR)
@@ -976,7 +1004,7 @@ def build_sync_scroll_row_func(*, group: str = DEFAULT_FUNC_GROUP_NAME) -> Func:
 
             # 行オフセットを加味した VRAM 書き込みアドレスをセット
             PUSH.HL(block)
-            LD.A_mn16(block, ADDR.TARGET_ROW)
+            LD.A_D(block)
             AND.n8(block, 0x07)
             if line_offset:
                 ADD.A_n8(block, line_offset)
@@ -1260,8 +1288,7 @@ def build_boot_bank(
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
 
     # ターゲット行は「新しく入ってきた上端の行」
-    LD.A_L(b)
-    LD.mn16_A(b, ADDR.TARGET_ROW)
+    LD.mn16_HL(b, ADDR.TARGET_ROW)
     JR(b, "DO_UPDATE_SCROLL")
 
     b.label("CHECK_DOWN")
@@ -1332,8 +1359,7 @@ def build_boot_bank(
     # ターゲット行は「新しく入ってきた下端の行 (開始行 + 23)」
     LD.BC_n16(b, 23)
     ADD.HL_BC(b)
-    LD.A_L(b)
-    LD.mn16_A(b, ADDR.TARGET_ROW)
+    LD.mn16_HL(b, ADDR.TARGET_ROW)
 
     b.label("DO_UPDATE_SCROLL")
     # 1. 新しい行の PG/CT を転送  ADDR,TARGET_ROW に行番号が入っている


### PR DESCRIPTION
### Motivation
- 縦長画像を下方向にスクロールしたときに開始位置や参照バンクがずれて表示が破綻する不具合を修正するため。
- 原因は `TARGET_ROW` が1バイトで行番号の上位ビットを扱えず、パターン/カラーバンク計算やVRAMアドレス決定が不整合になっていた点と推定されます。 

### Description
- `TARGET_ROW` を1バイトから2バイトに拡張し、`TARGET_ROW = madd("TARGET_ROW", 2)` に変更しました。
- `sync_scroll_row` の PG/CT 転送処理を 16bit の行番号（HL）を基にバンク計算・アドレス算出するよう書き換え、行オフセットの加算を HL 演算で行うように修正しました。
- 上下キー処理でターゲット行を保存する箇所を `LD.mn16_HL` を使って 16bit で格納するように変更しました。
- これに合わせてバンク切替（`ASCII16_PAGE2_REG`）や VRAM 書き込みアドレスの算出順序を調整しました。

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e4425fc2c8324973ebfaa3473b213)