### PR TITLE
マクロを画面表示切替へ改名し引数を bool に変更

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
@@ -21,6 +21,7 @@ __all__ = [
     "set_msx2_palette_default_macro",
     "init_screen2_macro",
     "set_screen_mode_macro",
+    "set_screen_display_macro",
     "set_text_cursor_macro",
     "write_text_with_cursor_macro",
     "write_text_with_cursor_macro_with_bios",
@@ -70,6 +71,7 @@ FORCLR = 0xF3E9  # 前景色
 BAKCLR = 0xF3EA  # 背景色
 BDRCLR = 0xF3EB  # 枠色
 MSXVER = 0x002D  # 0=MSX1, 1=MSX2, 2=2+, 3=turboR
+RG1SAV = 0xF3E0  # VDPレジスタ1のミラー
 
 VDP_DATA = 0x98   # VDPデータポート
 VDP_CTRL = 0x99   # VDPコントロールポート
@@ -393,6 +395,21 @@ def set_screen_mode_macro(b: Block, mode: int) -> None:
     """
     LD.A_n8(b, mode & 0xFF)
     b.emit(0xCD, CHGMOD & 0xFF, (CHGMOD >> 8) & 0xFF)
+
+
+def set_screen_display_macro(b: Block, display_on: bool) -> None:
+    """VDPレジスタ1のBit6を 0/1 に設定して画面表示を切り替えるマクロ。
+
+    レジスタ変更: A
+    """
+    LD.A_mn16(b, RG1SAV)
+    if display_on:
+        OR.n8(b, 0x40)
+    else:
+        AND.n8(b, 0xBF)
+    LD.mn16_A(b, RG1SAV)
+    OUT(b, VDP_CTRL)
+    OUT_A(b, VDP_CTRL, 0x80 + 1)
 
 
 def set_text_cursor_macro(b: Block, x: int, y: int) -> None:

--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
@@ -399,6 +399,7 @@ def set_screen_mode_macro(b: Block, mode: int) -> None:
 
 def set_screen_display_macro(b: Block, display_on: bool) -> None:
     """VDPレジスタ1のBit6を 0/1 に設定して画面表示を切り替えるマクロ。
+    画面非表示中は VDP アクセスをウェイト無しで行えるため、高速化に利用できる。
 
     レジスタ変更: A
     """


### PR DESCRIPTION
### Motivation
- VDPレジスタ1のBit6を明示的に切り替えて画面表示のON/OFFを制御するためのマクロを分かりやすくしたかった。 
- BIOSのミラー変数 `RG1SAV` を利用して安全にレジスタ値を更新して出力する設計を維持する必要があった。 
- マクロの用途を明確にするために名前と引数型をユーザに分かりやすい形に変更したかった。 
- 実装が汎用的なAPIであることを示すために、影響するレジスタ（A）を明記している。 

### Description
- `__all__` のエクスポート名を元のマクロから `set_screen_display_macro` に変更した。 
- 関数名を `set_screen_display_macro(b: Block, display_on: bool)` に改め、元の `Literal[0, 1]` 引数を `bool` に置換した。 
- `RG1SAV` を読み出して、`display_on` が True の場合は `OR 0x40`、False の場合は `AND 0xBF` を適用して `RG1SAV` に書き戻し、`VDP_CTRL` へ `OUT`/`OUT_A` を発行するようにした。 
- マクロのドキュメントにレジスタ変更（Aを使用/変更）を明記した。 

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f8c78ba8c8324a59b54243997a6b1)