### PR TITLE
CLIオプション `--vdp-wait` を追加して VDP WAIT を制御可能に (デフォルト NOWAIT)

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -263,6 +263,13 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="デバッグ用ビルドモードを有効にする。",
     )
+    parser.add_argument(
+        "--vdp-wait",
+        type=int_from_str,
+        choices=[0, 1],
+        default=0,
+        help="VDP WAITの設定 (0=NOWAIT, 1=WAIT)",
+    )
     return parser.parse_args()
 
 args = parse_args()
@@ -371,7 +378,10 @@ class ADDR:
         "CONFIG_AUTO_SCROLL", 1, initial_value=bytes([1]), description="自動スクロールの有効/無効"
     )
     CONFIG_VDP_WAIT = madd(
-        "CONFIG_VDP_WAIT", 1, initial_value=bytes([1]), description="VDP WAITの設定"
+        "CONFIG_VDP_WAIT",
+        1,
+        initial_value=bytes([args.vdp_wait]),
+        description="VDP WAITの設定",
     )
     AUTO_ADVANCE_COUNTER = madd(
         "AUTO_ADVANCE_COUNTER", 2, description="自動切り替えまでの残りフレーム"


### PR DESCRIPTION
### Motivation
- スクロールビルダーのランタイムで使用する VDP WAIT の既定値をビルド時に変更できるようにするため。 
- ユーザーがコマンドラインから `NOWAIT`/`WAIT` を切り替えられるようにする意図。 

### Description
- `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` に `--vdp-wait` 引数を追加し、受け付ける値を `0` または `1` に制限しました。 
- 追加した引数は `type=int_from_str`、`choices=[0,1]`、`default=0`（`0=NOWAIT, 1=WAIT`）に設定しています。 
- `ADDR.CONFIG_VDP_WAIT` の `initial_value` を従来の `bytes([1])` から `bytes([args.vdp_wait])` に差し替え、CLI の値で初期化するようにしました。 
- 変更対象ファイルは `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` です。 

### Testing
- 自動化されたテストは実行していません（今回の変更は CLI 引数の追加と初期値の差し替えに限定）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa4c89de8832492bd91d1fe2c71cc)