### PR TITLE
`CONFIG_BEEP_ENABLED` の初期値を `madd(..., initial_value=...)` に移動し起動時の初期化を削除

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -351,10 +351,16 @@ class ADDR:
     TARGET_ROW = madd("TARGET_ROW", 1)  # 更新する画像上の行番号
     VRAM_ROW_OFFSET = madd("VRAM_ROW_OFFSET", 1)  # VRAMブロック内の0-7行目オフセット
     CONFIG_BEEP_ENABLED = madd(
-        "CONFIG_BEEP_ENABLED", 1, description="BEEPの有効/無効"
+        "CONFIG_BEEP_ENABLED",
+        1,
+        initial_value=bytes([1 if args.beep else 0]),
+        description="BEEPの有効/無効",
     )
     CONFIG_BGM_ENABLED = madd(
-        "CONFIG_BGM_ENABLED", 1, description="BGMの有効/無効"
+        "CONFIG_BGM_ENABLED",
+        1,
+        initial_value=bytes([1 if args.bgm and args.bgm_path is not None else 0]),
+        description="BGMの有効/無効",
     )
     BGM_PTR_ADDR = madd(
         "BGM_PTR_ADDR", 2, description="BGMストリームの現在位置"
@@ -1275,18 +1281,6 @@ def build_boot_bank(
 
     # コンフィグの初期値を設定
     mem_addr_allocator.emit_initial_value_loader(b)
-    if beep_enabled_default:
-        LD.A_n8(b, 1)
-        LD.mn16_A(b, ADDR.CONFIG_BEEP_ENABLED)
-    else:
-        LD.A_n8(b, 0)
-        LD.mn16_A(b, ADDR.CONFIG_BEEP_ENABLED)
-    if bgm_enabled_default:
-        LD.A_n8(b, 1)
-        LD.mn16_A(b, ADDR.CONFIG_BGM_ENABLED)
-    else:
-        LD.A_n8(b, 0)
-        LD.mn16_A(b, ADDR.CONFIG_BGM_ENABLED)
     if bgm_start_bank is not None:
         LD.A_n8(b, bgm_start_bank & 0xFF)
         # LD.mn16_A(b, ADDR.BGM_BANK_ADDR)


### PR DESCRIPTION
### Motivation
- `CONFIG_BEEP_ENABLED` の初期値をビルド時に決めてランタイムで二重に初期化しないようにするため。 
- `CONFIG_VDP_WAIT` と同様に初期値を `madd` で一元管理したいため。 
- 起動時の冗長な初期化コードを削除して実装を簡潔にするため。 
- `args.beep` を初期値に反映させる必要があったため。 

### Description
- `CONFIG_BEEP_ENABLED` を `madd("CONFIG_BEEP_ENABLED", 1, initial_value=bytes([1 if args.beep else 0]), ...)` に変更しました。 
- 起動時に `ADDR.CONFIG_BEEP_ENABLED` と `ADDR.CONFIG_BGM_ENABLED` に書き込んでいたランタイム初期化コードを削除しました。 
- `mem_addr_allocator.emit_initial_value_loader(b)` の呼び出しは維持して初期値ローダー経由で配列を書き込む流れを保っています。 
- 変更は `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` の該当箇所に限定しています。 

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa795f4e08324a70bed5968aedb7f)