### PR TITLE
スクロールビューアに自動スクロール間隔と端待ちロジックを追加

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1570,7 +1570,7 @@ def build_boot_bank(
     b.label("CHECK_AUTO_SCROLL")
     LD.A_mn16(b, ADDR.CONFIG_AUTO_SCROLL)
     OR.A(b)
-    JR_Z(b, "CHECK_AUTO_PAGE")
+    JP_Z(b, "CHECK_AUTO_PAGE")
 
     # 端待ちカウンタが動作中なら優先して処理
     LD.HL_mn16(b, ADDR.AUTO_SCROLL_EDGE_WAIT)
@@ -1581,7 +1581,7 @@ def build_boot_bank(
     LD.mn16_HL(b, ADDR.AUTO_SCROLL_EDGE_WAIT)
     LD.A_H(b)
     OR.L(b)
-    JR_NZ(b, "CHECK_AUTO_PAGE")
+    JP_NZ(b, "CHECK_AUTO_PAGE")
     LD.HL_n16(b, 0)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
     DRAW_SCROLL_VIEW_FUNC.call(b)
@@ -1596,7 +1596,7 @@ def build_boot_bank(
     LD.D_mHL(b)
     EX.DE_HL(b)
     LD.mn16_HL(b, ADDR.AUTO_SCROLL_COUNTER)
-    JR(b, "CHECK_AUTO_PAGE")
+    JP(b, "CHECK_AUTO_PAGE")
 
     b.label("AUTO_SCROLL_COUNTER_CHECK")
     LD.HL_mn16(b, ADDR.AUTO_SCROLL_COUNTER)
@@ -1605,7 +1605,7 @@ def build_boot_bank(
     JR_Z(b, "AUTO_SCROLL_STEP")
     DEC.HL(b)
     LD.mn16_HL(b, ADDR.AUTO_SCROLL_COUNTER)
-    JR(b, "CHECK_AUTO_PAGE")
+    JP(b, "CHECK_AUTO_PAGE")
 
     b.label("AUTO_SCROLL_STEP")
     LD.A_mn16(b, ADDR.CONFIG_AUTO_SCROLL)
@@ -1652,7 +1652,7 @@ def build_boot_bank(
     LD.HL_mn16(b, ADDR.AUTO_SCROLL_EDGE_WAIT)
     LD.A_H(b)
     OR.L(b)
-    JR_NZ(b, "CHECK_AUTO_PAGE")
+    JP_NZ(b, "CHECK_AUTO_PAGE")
     LD.A_mn16(b, ADDR.CONFIG_AUTO_SCROLL)
     LD.L_A(b)
     LD.H_n8(b, 0)
@@ -1664,7 +1664,7 @@ def build_boot_bank(
     LD.D_mHL(b)
     EX.DE_HL(b)
     LD.mn16_HL(b, ADDR.AUTO_SCROLL_EDGE_WAIT)
-    JR(b, "CHECK_AUTO_PAGE")
+    JP(b, "CHECK_AUTO_PAGE")
 
     # --- 自動切り替え判定 ---
     b.label("CHECK_AUTO_PAGE")

--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1466,7 +1466,7 @@ def build_boot_bank(
     # ターゲット行は「新しく入ってきた上端の行」
     LD.A_L(b)
     LD.mn16_A(b, ADDR.TARGET_ROW)
-    JR(b, "DO_UPDATE_SCROLL")
+    JP(b, "DO_UPDATE_SCROLL")
 
     b.label("CHECK_DOWN")
     # 下キー判定
@@ -1646,7 +1646,7 @@ def build_boot_bank(
     ADD.HL_BC(b)
     LD.A_L(b)
     LD.mn16_A(b, ADDR.TARGET_ROW)
-    JR(b, "DO_UPDATE_SCROLL")
+    JP(b, "DO_UPDATE_SCROLL")
 
     b.label("AUTO_SCROLL_EDGE")
     LD.HL_mn16(b, ADDR.AUTO_SCROLL_EDGE_WAIT)


### PR DESCRIPTION
### Motivation
- 設定項目 `AUTO_SCROLL_LEVEL_CHOICES` に応じた自動スクロール挙動（NONEはスクロールなし、数値が大きいほど高速、末尾で折り返し、端では待機）を実装するための変更です。 
- スクロールの周期や端での待機時間をテーブル化して柔軟に調整できるようにするためです。 

### Description
- `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` に `AUTO_SCROLL_INTERVAL_FRAMES` と `AUTO_SCROLL_EDGE_WAIT_FRAMES` のテーブルを追加しました。 
- 自動スクロール用のワークメモリとして `AUTO_SCROLL_COUNTER` と `AUTO_SCROLL_EDGE_WAIT` を追加し、`UPDATE_IMAGE_DISPLAY` 内で初期化する処理を追加しました。 
- メインループに自動スクロール判定と処理を実装し、`CHECK_AUTO_SCROLL` / `AUTO_SCROLL_COUNTER_CHECK` / `AUTO_SCROLL_STEP` / `AUTO_SCROLL_EDGE` などのラベルで端待ち・折り返し・行送りの挙動を制御するようにしました。 
- 自動スクロール用テーブル `AUTO_SCROLL_INTERVAL_FRAMES_TABLE` と `AUTO_SCROLL_EDGE_WAIT_FRAMES_TABLE` をブートバンクの事前計算テーブル群に追加しました。 

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc4d828288324904c75f72438b9f5)