### PR TITLE
PSGストリームのマルチバンク対応と BGM FPS デフォルトを60に設定

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/psgstream.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/psgstream.py
@@ -12,6 +12,7 @@ from mmsxxasmhelper.core import (
     DJNZ,
     INC,
     JR,
+    JR_NZ,
     JR_Z,
     LD,
     OR,
@@ -29,8 +30,12 @@ def build_play_vgm_frame_func(
     vgm_timer_flag_addr: int,
     bgm_enabled_addr: int,
     vgm_bank_num: int | None = None,
+    vgm_bank_addr: int | None = None,
+    vgm_loop_bank_addr: int | None = None,
     current_bank_addr: int | None = None,
     page2_bank_reg_addr: int = 0x7000,
+    bank_base_addr: int = 0x8000,
+    bank_end_addr: int = 0xC000,
     fps30: bool = False,
 ) -> tuple[Callable[[Block], None], Callable[[Block], None], Callable[[Block], None]]:
     """
@@ -46,10 +51,26 @@ def build_play_vgm_frame_func(
         bgm_enabled_addr が 0 のときは即時リターンする。
         vgm_timer_flag_addr の 0/1 を反転し、0のとき再生処理をスキップする。
         vgm_bank_addr が指定されている場合、再生時にページ2バンクを切り替える。
+        vgm_bank_addr が指定されている場合、bank_end_addr を超えてアクセスしたら
+        vgm_bank_addr をインクリメントし、bank_base_addr に戻して次のバンクを再生する。
     """
 
     psg_reg_port = 0xA0
     psg_data_port = 0xA1
+
+    def maybe_switch_bank_after_inc(block: Block) -> None:
+        if vgm_bank_addr is None:
+            return
+        skip_switch = unique_label("PLAY_VGM_SKIP_BANK_SWITCH")
+        LD.A_H(block)
+        CP.n8(block, (bank_end_addr >> 8) & 0xFF)
+        JR_NZ(block, skip_switch)
+        LD.HL_n16(block, bank_base_addr)
+        LD.A_mn16(block, vgm_bank_addr)
+        INC.A(block)
+        LD.mn16_A(block, vgm_bank_addr)
+        LD.mn16_A(block, page2_bank_reg_addr)
+        block.label(skip_switch)
 
     def play_vgm_frame_macro(block: Block) -> None:
         loop_reg = unique_label("PLAY_VGM_LOOP")
@@ -60,6 +81,7 @@ def build_play_vgm_frame_func(
         LD.HL_mn16(block, vgm_ptr_addr)
         LD.A_mHL(block)
         INC.HL(block)
+        maybe_switch_bank_after_inc(block)
 
         CP.n8(block, 0xFF)
         JR_Z(block, do_loop)
@@ -72,9 +94,11 @@ def build_play_vgm_frame_func(
         LD.A_mHL(block)
         OUT(block, psg_reg_port)
         INC.HL(block)
+        maybe_switch_bank_after_inc(block)
         LD.A_mHL(block)
         OUT(block, psg_data_port)
         INC.HL(block)
+        maybe_switch_bank_after_inc(block)
         DJNZ(block, loop_reg)
 
         block.label(next_frame)
@@ -83,6 +107,11 @@ def build_play_vgm_frame_func(
 
         block.label(do_loop)
         LD.HL_mn16(block, vgm_loop_addr)
+        if vgm_loop_bank_addr is not None:
+            LD.A_mn16(block, vgm_loop_bank_addr)
+            if vgm_bank_addr is not None:
+                LD.mn16_A(block, vgm_bank_addr)
+            LD.mn16_A(block, page2_bank_reg_addr)
         LD.mn16_HL(block, vgm_ptr_addr)
         block.label(end_label)
 
@@ -116,7 +145,10 @@ def build_play_vgm_frame_func(
             LD.mn16_A(block, vgm_timer_flag_addr)
             JR_Z(block, skip_play)
 
-        if vgm_bank_num is not None:
+        if vgm_bank_addr is not None:
+            LD.A_mn16(block, vgm_bank_addr)
+            LD.mn16_A(block, page2_bank_reg_addr)
+        elif vgm_bank_num is not None:
             LD.A_n8(block, vgm_bank_num)
             LD.mn16_A(block, page2_bank_reg_addr)
         play_vgm_frame_macro(block)

--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -245,8 +245,8 @@ def parse_args() -> argparse.Namespace:
         "--bgm-fps",
         type=int,
         choices=[30, 60],
-        default=30,
-        help="BGM再生FPS (default: 30)",
+        default=60,
+        help="BGM再生FPS (default: 60)",
     )
     parser.add_argument(
         "--start-at",
@@ -376,9 +376,12 @@ class ADDR:
     BGM_LOOP_ADDR = madd(
         "BGM_LOOP_ADDR", 2, description="BGMストリームのループ先頭"
     )
-    # BGM_BANK_ADDR = madd(
-    #     "BGM_BANK_ADDR", 1, description="BGMストリームのバンク番号"
-    # )
+    BGM_BANK_ADDR = madd(
+        "BGM_BANK_ADDR", 1, description="BGMストリームの現在バンク番号"
+    )
+    BGM_LOOP_BANK_ADDR = madd(
+        "BGM_LOOP_BANK_ADDR", 1, description="BGMストリームのループ先頭バンク番号"
+    )
     CURRENT_PAGE2_BANK_ADDR = madd(
         "CURRENT_PAGE2_BANK_ADDR", 1, description="ページ2に設定中のバンク番号"
     )
@@ -1197,6 +1200,8 @@ def build_boot_bank(
         ADDR.VGM_TIMER_FLAG,
         ADDR.CONFIG_BGM_ENABLED,
         vgm_bank_num=bgm_start_bank,
+        vgm_bank_addr=ADDR.BGM_BANK_ADDR,
+        vgm_loop_bank_addr=ADDR.BGM_LOOP_BANK_ADDR,
         current_bank_addr=ADDR.CURRENT_PAGE2_BANK_ADDR,
         page2_bank_reg_addr=ASCII16_PAGE2_REG,
         fps30=bgm_fps == 30,
@@ -1293,7 +1298,8 @@ def build_boot_bank(
     mem_addr_allocator.emit_initial_value_loader(b)
     if bgm_start_bank is not None:
         LD.A_n8(b, bgm_start_bank & 0xFF)
-        # LD.mn16_A(b, ADDR.BGM_BANK_ADDR)
+        LD.mn16_A(b, ADDR.BGM_BANK_ADDR)
+        LD.mn16_A(b, ADDR.BGM_LOOP_BANK_ADDR)
         LD.HL_n16(b, DATA_BANK_ADDR)
         LD.mn16_HL(b, ADDR.BGM_PTR_ADDR)
         LD.mn16_HL(b, ADDR.BGM_LOOP_ADDR)
@@ -1738,7 +1744,7 @@ def build(
     title_wait_seconds: int = 3,
     beep_enabled_default: bool = True,
     bgm_enabled_default: bool = False,
-    bgm_fps: int = 30,
+    bgm_fps: int = 60,
     bgm_data: bytes | None = None,
     log_lines: list[str] | None = None,
     debug_build: bool = False,
@@ -1776,13 +1782,13 @@ def build(
     bgm_bank_count = 0
     bgm_start_bank: int | None = None
     if bgm_data is not None:
-        if len(bgm_data) > PAGE_SIZE:
-            bgm_data = bgm_data[:PAGE_SIZE]
         bgm_start_bank = next_bank
-        bgm_payload = bytearray([fill_byte] * PAGE_SIZE)
-        bgm_payload[: len(bgm_data)] = bgm_data
-        data_banks.append(bytes(bgm_payload))
-        bgm_bank_count = 1
+        bgm_bank_count = (len(bgm_data) + PAGE_SIZE - 1) // PAGE_SIZE
+        total_size = bgm_bank_count * PAGE_SIZE
+        padded = bytes(pad_bytes(list(bgm_data), total_size, fill_byte))
+        data_banks.extend(
+            padded[i : i + PAGE_SIZE] for i in range(0, total_size, PAGE_SIZE)
+        )
         next_bank += bgm_bank_count
 
     if start_positions is None:
@@ -2061,9 +2067,6 @@ def main() -> None:
         if not args.bgm_path.is_file():
             raise SystemExit(f"BGM file not found: {args.bgm_path}")
         bgm_data = args.bgm_path.read_bytes()
-        if len(bgm_data) > PAGE_SIZE:
-            log_and_store("BGM file size exceeds 16KB; truncating to 16KB", log_lines)
-            bgm_data = bgm_data[:PAGE_SIZE]
 
     rom = build(
         image_data_list,


### PR DESCRIPTION
### Motivation
- PSG(VGM) 再生が ROM バンク境界を跨ぐ BGM を扱えるようにし、スクロールビューアで複数バンクのBGMを格納・再生できるようにするため。 
- BGM再生の初期設定を一般的な60FPSに合わせるためにデフォルト値を更新するため。 

### Description
- `pyutils/mmsxxasmhelper/src/mmsxxasmhelper/psgstream.py` に `vgm_bank_addr` / `vgm_loop_bank_addr` と `bank_base_addr` / `bank_end_addr` を導入し、`maybe_switch_bank_after_inc` を追加してバンク末尾を越えた際のバンクインクリメントとページ2更新処理を挿入しました。 
- 同ファイルで ISR 側のページ2設定を RAM の `vgm_bank_addr` 値優先に変更し、ループ復帰時にループ先バンクを設定する処理を追加しました。 
- `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` に RAM エントリとして `BGM_BANK_ADDR` と `BGM_LOOP_BANK_ADDR` を追加して初期化コードと `build_play_vgm_frame_func` 呼び出しで使用するようにし、初期ロード時にバンク番号を設定する処理を追加しました。 
- BGMのパッキングロジックをページ単位に拡張して複数バンク分を `data_banks` に分割格納するようにし、16KBでの切り捨てを廃止し代わりにページ単位でパディングして格納するようにしました。 
- CLI と API のデフォルトを `--bgm-fps` と `build()` の `bgm_fps` 引数ともに `60` に変更しました。 

### Testing
- 自動テストは実行していません（今回の変更はアセンブリ生成やバンク配置に影響するため実機/環境での動作確認を推奨します）。
- 既存のリポジトリ内テスト群は今回の変更で未実行のままです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc80badec83248b2f7dfd452d015b)