### PR TITLE
自動スクロール折返し開始でページ遷移をトリガーするよう変更

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1602,6 +1602,11 @@ def build_boot_bank(
     LD.A_H(b)
     OR.L(b)
     JP_NZ(b, "CHECK_AUTO_PAGE")
+    LD.A_mn16(b, ADDR.AUTO_SCROLL_TURN_STATE)
+    CP.n8(b, 1)
+    JR_NZ(b, "CHECK_AUTO_PAGE")
+    LD.A_n8(b, 2)
+    LD.mn16_A(b, ADDR.AUTO_SCROLL_TURN_STATE)
     JP(b, "CHECK_AUTO_PAGE")
 
     b.label("AUTO_SCROLL_COUNTER_CHECK")

--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1602,8 +1602,6 @@ def build_boot_bank(
     LD.A_H(b)
     OR.L(b)
     JP_NZ(b, "CHECK_AUTO_PAGE")
-    LD.A_n8(b, 2)
-    LD.mn16_A(b, ADDR.AUTO_SCROLL_TURN_STATE)
     JP(b, "CHECK_AUTO_PAGE")
 
     b.label("AUTO_SCROLL_COUNTER_CHECK")
@@ -1628,7 +1626,14 @@ def build_boot_bank(
     EX.DE_HL(b)
     LD.mn16_HL(b, ADDR.AUTO_SCROLL_COUNTER)
 
+    LD.A_mn16(b, ADDR.AUTO_SCROLL_TURN_STATE)
+    CP.n8(b, 1)
+    JR_NZ(b, "AUTO_SCROLL_STEP_DIR")
+    LD.A_n8(b, 2)
+    LD.mn16_A(b, ADDR.AUTO_SCROLL_TURN_STATE)
+
     # 方向に応じて端判定と移動
+    b.label("AUTO_SCROLL_STEP_DIR")
     LD.A_mn16(b, ADDR.AUTO_SCROLL_DIR)
     CP.n8(b, 1)
     JP_Z(b, "AUTO_SCROLL_DOWN")

--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1604,7 +1604,7 @@ def build_boot_bank(
     JP_NZ(b, "CHECK_AUTO_PAGE")
     LD.A_mn16(b, ADDR.AUTO_SCROLL_TURN_STATE)
     CP.n8(b, 1)
-    JR_NZ(b, "CHECK_AUTO_PAGE")
+    JP_NZ(b, "CHECK_AUTO_PAGE")
     LD.A_n8(b, 2)
     LD.mn16_A(b, ADDR.AUTO_SCROLL_TURN_STATE)
     JP(b, "CHECK_AUTO_PAGE")

--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1744,6 +1744,11 @@ def build_boot_bank(
     JR(b, "CHECK_GRAPH")
 
     b.label("AUTO_PAGE_EDGE_CHECK")
+    LD.HL_mn16(b, ADDR.CURRENT_IMAGE_ROW_COUNT_ADDR)
+    LD.BC_n16(b, 24)
+    OR.A(b)
+    SBC.HL_BC(b)
+    JR_C(b, "AUTO_NEXT_IMAGE")
     LD.A_mn16(b, ADDR.AUTO_SCROLL_TURN_STATE)
     CP.n8(b, 2)
     JR_NZ(b, "CHECK_GRAPH")


### PR DESCRIPTION
### Motivation
- 自動スクロールが端に到達したときの挙動を、到達時ではなく折返しが始まるタイミングでページ遷移させるための修正です。たどり着いた時点でページ遷移しないようにする要望に対応しています。 
- 既存の折返し状態遷移ロジックがスクロールステップ側に分散していたため、検出タイミングを端待ち完了側に統一します。

### Description
- `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` に `AUTO_SCROLL_TURN_STATE` を追加して折返し状態 (`0=なし,1=待機,2=開始`) を管理するようにしました (`ADDR.AUTO_SCROLL_TURN_STATE`)。 
- 更新処理 `UPDATE_IMAGE_DISPLAY` 内で `AUTO_SCROLL_TURN_STATE` を初期化 (`XOR.A` → `LD.mn16_A`) するようにしました。 
- 端到達時は待機状態 `1` をセットし、端待ちカウンタがゼロになったタイミングで即 `2`（折返し開始）をセットするようにして、折返し開始で自動ページ遷移を発生させます（`AUTO_PAGE_EDGE_CHECK` で `== 2` を判定して遷移し、遷移後にフラグをクリア）。 
- 自動スクロールステップ側にあった重複した `turn_state` の昇格処理を削除してロジックを簡素化しました。 

### Testing
- 自動化テストは実行していません。 
- CIビルドやエミュレーションなどの自動検証は未実施です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fd0216ed0832490a6c501ca1fef5e)