### PR TITLE
PSGストリームの複数バンク再生対応とBGMデータ多バンク格納

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/psgstream.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/psgstream.py
@@ -12,6 +12,7 @@ from mmsxxasmhelper.core import (
     DJNZ,
     INC,
     JR,
+    JR_NZ,
     JR_Z,
     LD,
     OR,
@@ -29,6 +30,8 @@ def build_play_vgm_frame_func(
     vgm_timer_flag_addr: int,
     bgm_enabled_addr: int,
     vgm_bank_num: int | None = None,
+    vgm_bank_addr: int | None = None,
+    vgm_loop_bank_addr: int | None = None,
     current_bank_addr: int | None = None,
     page2_bank_reg_addr: int = 0x7000,
     fps30: bool = False,
@@ -46,10 +49,12 @@ def build_play_vgm_frame_func(
         bgm_enabled_addr が 0 のときは即時リターンする。
         vgm_timer_flag_addr の 0/1 を反転し、0のとき再生処理をスキップする。
         vgm_bank_addr が指定されている場合、再生時にページ2バンクを切り替える。
+        vgm_bank_addr 指定時は、VGMポインタがバンク末尾を超えたら次バンクへ移行する。
     """
 
     psg_reg_port = 0xA0
     psg_data_port = 0xA1
+    page2_bank_base_addr = 0x8000
 
     def play_vgm_frame_macro(block: Block) -> None:
         loop_reg = unique_label("PLAY_VGM_LOOP")
@@ -57,9 +62,24 @@ def build_play_vgm_frame_func(
         do_loop = unique_label("PLAY_VGM_DO_LOOP")
         end_label = unique_label("PLAY_VGM_END")
 
+        def maybe_switch_bank() -> None:
+            if vgm_bank_addr is None:
+                return
+            bank_ok = unique_label("PLAY_VGM_BANK_OK")
+            LD.A_H(block)
+            CP.n8(block, 0xC0)
+            JR_NZ(block, bank_ok)
+            LD.HL_n16(block, page2_bank_base_addr)
+            LD.A_mn16(block, vgm_bank_addr)
+            INC.A(block)
+            LD.mn16_A(block, vgm_bank_addr)
+            LD.mn16_A(block, page2_bank_reg_addr)
+            block.label(bank_ok)
+
         LD.HL_mn16(block, vgm_ptr_addr)
         LD.A_mHL(block)
         INC.HL(block)
+        maybe_switch_bank()
 
         CP.n8(block, 0xFF)
         JR_Z(block, do_loop)
@@ -72,9 +92,11 @@ def build_play_vgm_frame_func(
         LD.A_mHL(block)
         OUT(block, psg_reg_port)
         INC.HL(block)
+        maybe_switch_bank()
         LD.A_mHL(block)
         OUT(block, psg_data_port)
         INC.HL(block)
+        maybe_switch_bank()
         DJNZ(block, loop_reg)
 
         block.label(next_frame)
@@ -83,6 +105,10 @@ def build_play_vgm_frame_func(
 
         block.label(do_loop)
         LD.HL_mn16(block, vgm_loop_addr)
+        if vgm_loop_bank_addr is not None and vgm_bank_addr is not None:
+            LD.A_mn16(block, vgm_loop_bank_addr)
+            LD.mn16_A(block, vgm_bank_addr)
+            LD.mn16_A(block, page2_bank_reg_addr)
         LD.mn16_HL(block, vgm_ptr_addr)
         block.label(end_label)
 
@@ -116,7 +142,10 @@ def build_play_vgm_frame_func(
             LD.mn16_A(block, vgm_timer_flag_addr)
             JR_Z(block, skip_play)
 
-        if vgm_bank_num is not None:
+        if vgm_bank_addr is not None:
+            LD.A_mn16(block, vgm_bank_addr)
+            LD.mn16_A(block, page2_bank_reg_addr)
+        elif vgm_bank_num is not None:
             LD.A_n8(block, vgm_bank_num)
             LD.mn16_A(block, page2_bank_reg_addr)
         play_vgm_frame_macro(block)

--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -400,9 +400,12 @@ class ADDR:
     BGM_LOOP_ADDR = madd(
         "BGM_LOOP_ADDR", 2, description="BGMストリームのループ先頭"
     )
-    # BGM_BANK_ADDR = madd(
-    #     "BGM_BANK_ADDR", 1, description="BGMストリームのバンク番号"
-    # )
+    BGM_BANK_ADDR = madd(
+        "BGM_BANK_ADDR", 1, description="BGMストリームの現在バンク番号"
+    )
+    BGM_LOOP_BANK_ADDR = madd(
+        "BGM_LOOP_BANK_ADDR", 1, description="BGMストリームのループ先頭バンク番号"
+    )
     CURRENT_PAGE2_BANK_ADDR = madd(
         "CURRENT_PAGE2_BANK_ADDR", 1, description="ページ2に設定中のバンク番号"
     )
@@ -1260,6 +1263,8 @@ def build_boot_bank(
         ADDR.VGM_TIMER_FLAG,
         ADDR.CONFIG_BGM_ENABLED,
         vgm_bank_num=bgm_start_bank,
+        vgm_bank_addr=ADDR.BGM_BANK_ADDR,
+        vgm_loop_bank_addr=ADDR.BGM_LOOP_BANK_ADDR,
         current_bank_addr=ADDR.CURRENT_PAGE2_BANK_ADDR,
         page2_bank_reg_addr=ASCII16_PAGE2_REG,
         fps30=bgm_fps == 30,
@@ -1356,7 +1361,8 @@ def build_boot_bank(
     mem_addr_allocator.emit_initial_value_loader(b)
     if bgm_start_bank is not None:
         LD.A_n8(b, bgm_start_bank & 0xFF)
-        # LD.mn16_A(b, ADDR.BGM_BANK_ADDR)
+        LD.mn16_A(b, ADDR.BGM_BANK_ADDR)
+        LD.mn16_A(b, ADDR.BGM_LOOP_BANK_ADDR)
         LD.HL_n16(b, DATA_BANK_ADDR)
         LD.mn16_HL(b, ADDR.BGM_PTR_ADDR)
         LD.mn16_HL(b, ADDR.BGM_LOOP_ADDR)
@@ -2016,13 +2022,16 @@ def build(
     bgm_bank_count = 0
     bgm_start_bank: int | None = None
     if bgm_data is not None:
-        if len(bgm_data) > PAGE_SIZE:
-            bgm_data = bgm_data[:PAGE_SIZE]
         bgm_start_bank = next_bank
-        bgm_payload = bytearray([fill_byte] * PAGE_SIZE)
-        bgm_payload[: len(bgm_data)] = bgm_data
-        data_banks.append(bytes(bgm_payload))
-        bgm_bank_count = 1
+        bgm_bank_count = max(1, (len(bgm_data) + PAGE_SIZE - 1) // PAGE_SIZE)
+        if next_bank + bgm_bank_count > 0x100:
+            raise ValueError("BGM data exceeds available bank range")
+        for idx in range(bgm_bank_count):
+            bgm_payload = bytearray([fill_byte] * PAGE_SIZE)
+            start = idx * PAGE_SIZE
+            end = start + PAGE_SIZE
+            bgm_payload[: max(0, min(PAGE_SIZE, len(bgm_data) - start))] = bgm_data[start:end]
+            data_banks.append(bytes(bgm_payload))
         next_bank += bgm_bank_count
 
     if start_positions is None:
@@ -2301,9 +2310,6 @@ def main() -> None:
         if not args.bgm_path.is_file():
             raise SystemExit(f"BGM file not found: {args.bgm_path}")
         bgm_data = args.bgm_path.read_bytes()
-        if len(bgm_data) > PAGE_SIZE:
-            log_and_store("BGM file size exceeds 16KB; truncating to 16KB", log_lines)
-            bgm_data = bgm_data[:PAGE_SIZE]
 
     rom = build(
         image_data_list,


### PR DESCRIPTION
### Motivation

- VGM/PSG ストリームが単一バンクに収まらない場合でも正しく再生できるようにするため。 
- 再生中にVGMポインタがバンク境界を超えた際に自動で次バンクへ切り替えたい。 
- ループ時にバンク情報を復帰させ、ループ先が別バンクにあるケースをサポートするため。 
- 既存の BGM 読み込みでの単一バンクへのトランケートを撤廃してデータ損失を防ぐため。 

### Description

- `build_play_vgm_frame_func` に `vgm_bank_addr` と `vgm_loop_bank_addr` を追加し、RAM に格納したバンク番号を参照して再生時にページ2バンクを切り替えるロジックを実装しました（`psgstream.py`）。
- 再生中のポインタ位置に応じたバンク遷移を行う内部関数 `maybe_switch_bank` を導入し、VGM ポインタがバンク末尾を越えた際にバンクをインクリメントして `page2` レジスタを更新するようにしました（ループ時は `vgm_loop_bank_addr` を用いて復帰）。
- 起動時メモリに `BGM_BANK_ADDR` / `BGM_LOOP_BANK_ADDR` を追加し、BGM の初期バンク情報を書き込むように変更しました（`create_scroll_megarom.py`）。
- BGM ファイルの取り扱いを見直し、読み込んだ `bgm_data` を `PAGE_SIZE` 単位で分割して複数バンクに格納するようにしてトランケートを撤廃し、利用可能なバンク範囲を越える場合はエラーにするチェックを追加しました。 

### Testing

- 自動テストは実行していません（今回の変更は組み込みコード生成およびバイナリ配置に関するため、現状での自動化検証は未実施です）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fdda028b8832484da31155042acc5)