### PR TITLE
スクロール方向の状態を追加

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -436,6 +436,9 @@ class ADDR:
     AUTO_SCROLL_DIR = madd(
         "AUTO_SCROLL_DIR", 1, description="自動スクロール方向 (1=下,255=上)"
     )
+    SCROLL_MOVE_DIR = madd(
+        "SCROLL_MOVE_DIR", 1, description="スクロール方向 (1=下,255=上)"
+    )
     AUTO_SCROLL_TURN_STATE = madd(
         "AUTO_SCROLL_TURN_STATE", 1, description="自動スクロール折返し状態 (0=なし,1=待機,2=開始)"
     )
@@ -961,12 +964,16 @@ def build_update_image_display_func(
         LD.HL_n16(block, 0)
         block.label(INIT_POS_OK)
         LD.mn16_HL(block, ADDR.CURRENT_SCROLL_ROW)
+        LD.A_n8(block, 0xFF)
+        LD.mn16_A(block, ADDR.SCROLL_MOVE_DIR)
         JR(block, "_INIT_POS_DONE")
 
         # 上端開始: 常に 0
         block.label(INIT_FROM_TOP)
         LD.HL_n16(block, 0)
         LD.mn16_HL(block, ADDR.CURRENT_SCROLL_ROW)
+        LD.A_n8(block, 1)
+        LD.mn16_A(block, ADDR.SCROLL_MOVE_DIR)
 
         block.label("_INIT_POS_DONE")
 
@@ -1000,7 +1007,7 @@ def build_update_image_display_func(
         LD.mn16_HL(block, ADDR.AUTO_SCROLL_COUNTER)
         LD.HL_n16(block, 0)
         LD.mn16_HL(block, ADDR.AUTO_SCROLL_EDGE_WAIT)
-        LD.A_n8(block, 1)
+        LD.A_mn16(block, ADDR.SCROLL_MOVE_DIR)
         LD.mn16_A(block, ADDR.AUTO_SCROLL_DIR)
         XOR.A(block)
         LD.mn16_A(block, ADDR.AUTO_SCROLL_TURN_STATE)
@@ -1469,6 +1476,8 @@ def build_boot_bank(
     LD.HL_n16(b, 0)
 
     b.label("SHIFT_UP_STORE")
+    LD.A_n8(b, 0xFF)
+    LD.mn16_A(b, ADDR.SCROLL_MOVE_DIR)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
     DRAW_SCROLL_VIEW_FUNC.call(b)
     JP(b, "CHECK_AUTO_SCROLL")
@@ -1480,6 +1489,8 @@ def build_boot_bank(
     LD.A_H(b)
     OR.L(b)
     JR_Z(b, "CHECK_DOWN")
+    LD.A_n8(b, 0xFF)
+    LD.mn16_A(b, ADDR.SCROLL_MOVE_DIR)
     DEC.HL(b)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
 
@@ -1528,6 +1539,8 @@ def build_boot_bank(
     POP.HL(b)
 
     b.label("SHIFT_DOWN_STORE")
+    LD.A_n8(b, 1)
+    LD.mn16_A(b, ADDR.SCROLL_MOVE_DIR)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
     DRAW_SCROLL_VIEW_FUNC.call(b)
     JP(b, "CHECK_AUTO_SCROLL")
@@ -1550,6 +1563,8 @@ def build_boot_bank(
 
     # 1行下へ移動
     LD.HL_mn16(b, ADDR.CURRENT_SCROLL_ROW)
+    LD.A_n8(b, 1)
+    LD.mn16_A(b, ADDR.SCROLL_MOVE_DIR)
     INC.HL(b)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
 
@@ -1648,6 +1663,8 @@ def build_boot_bank(
     LD.A_H(b)
     OR.L(b)
     JP_Z(b, "AUTO_SCROLL_EDGE_TOP")
+    LD.A_n8(b, 0xFF)
+    LD.mn16_A(b, ADDR.SCROLL_MOVE_DIR)
     DEC.HL(b)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
     LD.A_L(b)
@@ -1672,6 +1689,7 @@ def build_boot_bank(
     LD.mn16_HL(b, ADDR.AUTO_SCROLL_EDGE_WAIT)
     LD.A_n8(b, 1)
     LD.mn16_A(b, ADDR.AUTO_SCROLL_DIR)
+    LD.mn16_A(b, ADDR.SCROLL_MOVE_DIR)
     LD.A_n8(b, 1)
     LD.mn16_A(b, ADDR.AUTO_SCROLL_TURN_STATE)
     JP(b, "CHECK_AUTO_PAGE")
@@ -1695,6 +1713,8 @@ def build_boot_bank(
     LD.HL_n16(b, 0)
     LD.mn16_HL(b, ADDR.AUTO_SCROLL_EDGE_WAIT)
     LD.HL_mn16(b, ADDR.CURRENT_SCROLL_ROW)
+    LD.A_n8(b, 1)
+    LD.mn16_A(b, ADDR.SCROLL_MOVE_DIR)
     INC.HL(b)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
 
@@ -1723,6 +1743,7 @@ def build_boot_bank(
     LD.mn16_HL(b, ADDR.AUTO_SCROLL_EDGE_WAIT)
     LD.A_n8(b, 0xFF)
     LD.mn16_A(b, ADDR.AUTO_SCROLL_DIR)
+    LD.mn16_A(b, ADDR.SCROLL_MOVE_DIR)
     LD.A_n8(b, 1)
     LD.mn16_A(b, ADDR.AUTO_SCROLL_TURN_STATE)
     JP(b, "CHECK_AUTO_PAGE")


### PR DESCRIPTION
### Motivation
- 下スクロール時に画面が乱れる問題に対処するため、スクロールの進行方向を別バイトで保持して処理を分離する必要があると判断した。
- `build_sync_scroll_row_func` だけで対応するのが困難なため、キー操作と自動スクロールで共通に参照できる状態を追加する意図。 

### Description
- ワークRAMに `SCROLL_MOVE_DIR` を追加してスクロールの現在方向（`1`=下, `255`=上）を保持するようにした。 (`pyutils/sc2_viewer_rom/src/create_scroll_megarom.py`)
- 画像初期化時に `CURRENT_SCROLL_ROW` と合わせて `SCROLL_MOVE_DIR` を初期化するように変更した。 (`UPDATE_IMAGE_DISPLAY`) 
- 手動スクロール処理（上下キー、SHIFTによる8行ジャンプ）で移動時に `SCROLL_MOVE_DIR` を更新するようにした。 (`MAIN_LOOP` 内の入力処理)
- 自動スクロール処理でも端判定／折返しの箇所で `SCROLL_MOVE_DIR` を更新するようにした。 (`AUTO_SCROLL` 関連ラベル群)

### Testing
- 自動化されたテストは実行していません。 
- 変更は1ファイル `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` に対して行われ、コードはコミットされています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ff34079408324ad35fcb63c0c9171)