### PR TITLE
同期スクロールで上下向き別のオフセットを導入

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1031,7 +1031,18 @@ BEEP_WRITE_FUNC, SIMPLE_BEEP_FUNC, UPDATE_BEEP_FUNC = build_beep_control_utils(
 def build_sync_scroll_row_func(
     *, scroll_dir: str, group: str = DEFAULT_FUNC_GROUP_NAME
 ) -> Func:
+    scroll_configs = {
+        "up": ((0, 0), (8, 8), (16, 16)),
+        "down": ((0, -16), (8, -8), (16, 0)),
+    }
+    scroll_config = scroll_configs[scroll_dir]
+
     def sync_scroll_row(block: Block) -> None:
+        # VRAM内の物理行 (0-7) を計算して保存
+        LD.A_mn16(block, ADDR.TARGET_ROW)
+        AND.n8(block, 0x07)
+        LD.mn16_A(block, ADDR.VRAM_ROW_OFFSET)
+
         # --- ① パターン (PG) 転送準備 ---
         # 行番号から2bit分を切り出してパターンバンク番号として使い、
         # タイルデータが格納されているROMバンクをページ2に接続する。
@@ -1056,10 +1067,12 @@ def build_sync_scroll_row_func(
 
         # --- カラー (CT) 転送 ---
         # 表示行に対応するカラー定義を 0/8/16 ライン先頭で VRAM へ直接出力する。
-        for line_offset in [0, 8, 16]:
+        for line_offset, img_adjust in scroll_config:
             LD.A_mn16(block, ADDR.TARGET_ROW)
-            if line_offset:
-                ADD.A_n8(block, line_offset)
+            if img_adjust > 0:
+                ADD.A_n8(block, img_adjust)
+            elif img_adjust < 0:
+                SUB.n8(block, -img_adjust)
             LD.D_A(block)
 
             # カラーデータのバンクを初期化
@@ -1091,8 +1104,7 @@ def build_sync_scroll_row_func(
             LD.L_n8(block, 0)
 
             PUSH.HL(block)
-            LD.A_mn16(block, ADDR.TARGET_ROW)
-            AND.n8(block, 0x07)
+            LD.A_mn16(block, ADDR.VRAM_ROW_OFFSET)
             ADD.A_n8(block, 0x20 + line_offset)
             LD.H_A(block)
             LD.L_n8(block, 0)
@@ -1106,11 +1118,13 @@ def build_sync_scroll_row_func(
         # 画面横32タイル分のパターンデータを3ブロックぶんそのまま転送する。
         # スクロール位置が1ライン進むとそれぞれ8ライン間隔で参照先がずれるため、
         # 0/8/16 ライン先頭を VRAM の各ミラー領域へ直接出力する。
-        for line_offset in [0, 8, 16]:
+        for line_offset, img_adjust in scroll_config:
             # 行番号にオフセットを加味し、対象バンクを決定。
             LD.A_mn16(block, ADDR.TARGET_ROW)
-            if line_offset:
-                ADD.A_n8(block, line_offset)
+            if img_adjust > 0:
+                ADD.A_n8(block, img_adjust)
+            elif img_adjust < 0:
+                SUB.n8(block, -img_adjust)
             LD.D_A(block)  # 後続のアドレス計算用に保持
 
             RLCA(block)
@@ -1132,8 +1146,7 @@ def build_sync_scroll_row_func(
 
             # 行オフセットを加味した VRAM 書き込みアドレスをセット
             PUSH.HL(block)
-            LD.A_mn16(block, ADDR.TARGET_ROW)
-            AND.n8(block, 0x07)
+            LD.A_mn16(block, ADDR.VRAM_ROW_OFFSET)
             if line_offset:
                 ADD.A_n8(block, line_offset)
             LD.H_A(block)

--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1624,12 +1624,12 @@ def build_boot_bank(
     # 2. 新しい行の PG/CT を転送  ADDR,TARGET_ROW に行番号が入っている
     LD.A_mn16(b, ADDR.AUTO_SCROLL_DIR)
     CP.n8(b, 1)
-    JR_Z(b, "SYNC_SCROLL_ROW_DOWN")
+    JR_Z(b, "SYNC_SCROLL_ROW_UP_DOWN")
     SYNC_UP_SCROLL_ROW_FUNC.call(b)
-    JR(b, "SYNC_SCROLL_ROW_DONE")
-    b.label("SYNC_SCROLL_ROW_DOWN")
+    JR(b, "SYNC_SCROLL_ROW_UP_DOWN_DONE")
+    b.label("SYNC_SCROLL_ROW_UP_DOWN")
     SYNC_DOWN_SCROLL_ROW_FUNC.call(b)
-    b.label("SYNC_SCROLL_ROW_DONE")
+    b.label("SYNC_SCROLL_ROW_UP_DOWN_DONE")
 
     JP(b, "CHECK_AUTO_PAGE")
 
@@ -2397,3 +2397,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
### Motivation

- 同じ処理になっていた上方向/下方向の同期スクロール処理を、方向ごとに異なるオフセットで動作させるための分岐を導入する。 
- VRAMへの書き込み位置や参照行を方向毎に正しく切り替え、表示のズレやミラー領域の不整合を防ぐ。 
- 既存の最適化方針を崩さず、処理負荷を不必要に増やさない実装とする。 

### Description

- `build_sync_scroll_row_func` に `scroll_configs` を追加して、`"up"`/`"down"` 向けの `(line_offset, img_adjust)` ペアを定義した。 
- ターゲット行から VRAM 内の物理行 (0-7) を算出して `ADDR.VRAM_ROW_OFFSET` に保存する処理を追加し再利用するようにした。 
- カラー転送とパターン転送のループを `for line_offset, img_adjust in scroll_config:` に差し替え、`img_adjust` の符号に応じて `ADD.A_n8` / `SUB.n8` を使って参照行を補正するようにした。 
- VRAM 書き込み先のアドレス計算でこれまでの `ADDR.TARGET_ROW` 直接参照をやめ、計算済みの `ADDR.VRAM_ROW_OFFSET` と `line_offset` を使うように変更した。 

### Testing

- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696009324c5c8324862ee0c5d63ee5ea)