### PR TITLE
自動スクロール時に `ADDR.SCROLL_DIRECTION` を設定する

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1650,6 +1650,9 @@ def build_boot_bank(
     JP_Z(b, "AUTO_SCROLL_EDGE_TOP")
     DEC.HL(b)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
+    # --- 自動スクロール時の方向フラグ(0=上)をセット ---
+    XOR.A(b)
+    LD.mn16_A(b, ADDR.SCROLL_DIRECTION)
     LD.A_L(b)
     LD.mn16_A(b, ADDR.TARGET_ROW)
     JP(b, "DO_UPDATE_SCROLL")
@@ -1697,6 +1700,9 @@ def build_boot_bank(
     LD.HL_mn16(b, ADDR.CURRENT_SCROLL_ROW)
     INC.HL(b)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
+    # --- 自動スクロール時の方向フラグ(1=下)をセット ---
+    LD.A_n8(b, 1)
+    LD.mn16_A(b, ADDR.SCROLL_DIRECTION)
 
     # ターゲット行は「新しく入ってきた下端の行 (開始行 + 23)」
     LD.BC_n16(b, 23)


### PR DESCRIPTION
### Motivation
- スクロール処理で上/下で別関数 (`SYNC_SCROLL_UP_FUNC` / `SYNC_SCROLL_DOWN_FUNC`) を呼び分けるために `ADDR.SCROLL_DIRECTION` を保持する必要がある。
- 上下キー入力時は `ADDR.SCROLL_DIRECTION` を設定しているが、自動スクロール時は未設定のままであった。
- 自動スクロールでも方向フラグを設定して同期行転送関数呼び出し時に正しい方向情報を渡せるようにする。

### Description
- `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` の自動スクロール処理に手を入れ、上スクロール側で `XOR.A` と `LD.mn16_A(...ADDR.SCROLL_DIRECTION)` を追加して `0` (上) を設定した。
- 同ファイルの下スクロール側で `LD.A_n8(b, 1)` と `LD.mn16_A(...ADDR.SCROLL_DIRECTION)` を追加して `1` (下) を設定した。
- 変更は自動スクロール分岐ラベル（例: `AUTO_SCROLL_STEP_DIR`/`AUTO_SCROLL_DOWN`）の処理内に挿入されている。
- 変更内容はコミット済み (`Set scroll direction for auto scrolling`)。

### Testing
- 自動テスト（ユニットテスト / CI）は実行していません。
- ビルドや実機動作確認などの自動化された検証も行っていません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960bd92f5c08324a00babaebc9260de)