### PR TITLE
VDP WAIT モードを YES/PARTIAL の2択に制限し転送ロジックを簡素化

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
@@ -1002,7 +1002,7 @@ def build_scroll_name_table_func2(
     OUTI_256_FUNC: Func,
     OUTI_256_FUNC_NO_WAIT: Func | None = None,  # Noneを許容
     *,
-    use_no_wait: Literal["NO", "ONE_BLOCK", "ALL"] = "NO",                  # 生成時のフラグ
+    use_no_wait: Literal["PARTIAL", "YES"] = "PARTIAL",                     # 生成時のフラグ
     group: str = DEFAULT_FUNC_GROUP_NAME
 ) -> Func:
     """
@@ -1010,7 +1010,7 @@ def build_scroll_name_table_func2(
     生成時に use_no_wait=True かつ NO_WAIT関数がない場合はエラーを出す。
     """
     # エラーチェック
-    if use_no_wait != "NO" and OUTI_256_FUNC_NO_WAIT is None:
+    if OUTI_256_FUNC_NO_WAIT is None:
         raise ValueError(f"use_no_wait[{use_no_wait}] requires OUTI_256_FUNC_NO_WAIT to be provided.")
 
     def scroll_name_table(block: Block) -> None:
@@ -1038,22 +1038,19 @@ def build_scroll_name_table_func2(
         # --- 第1ブロック (上段) ---
         POP.HL(block)
         PUSH.HL(block)
-        if use_no_wait != "NO":
-            OUTI_256_FUNC_NO_WAIT.call(block)
-        else:
-            OUTI_256_FUNC.call(block)
+        OUTI_256_FUNC_NO_WAIT.call(block)
 
         # --- 第2・3ブロック (中・下段) ---
         # 表示期間に食い込むため常に通常版を使用
         POP.HL(block)
         PUSH.HL(block)
-        if use_no_wait == "ALL":
+        if use_no_wait == "YES":
             OUTI_256_FUNC_NO_WAIT.call(block)
         else:
             OUTI_256_FUNC.call(block)
 
         POP.HL(block)
-        if use_no_wait == "ALL":
+        if use_no_wait == "YES":
             OUTI_256_FUNC_NO_WAIT.call(block)
         else:
             OUTI_256_FUNC.call(block)


### PR DESCRIPTION
### Motivation
- VDP WAIT の表記と挙動を直感的にしてモード数を減らすために `NOWAIT` 系の選択肢を整理しました。 
- 名前テーブル転送の分岐を簡素化して呼び出しロジックを一元化するためです。 
- `OUTI_256_FUNC_NO_WAIT` がない場合の不整合を防ぐために生成時の検証を強化するためです。 
- 描画／ブート処理の個別分岐を削除し、モード選択を単一の呼び出しに置換するためです。

### Description
- `pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py` の `build_scroll_name_table_func2` を `use_no_wait: Literal["PARTIAL","YES"] = "PARTIAL"` に変更し、`OUTI_256_FUNC_NO_WAIT` が必須である旨の検証を追加しました。 
- 同関数内で第1ブロックの転送は常に `OUTI_256_FUNC_NO_WAIT.call(...)` を使うように整理し、第2/3ブロックのみ `use_no_wait == "YES"` のときに NO_WAIT を使用するようにしました。 
- `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` 側で通常の名前テーブル転送を `build_scroll_name_table_func` に切り替え、`SCROLL_NAME_TABLE_FUNC_NOWAIT_PARTIAL` / `SCROLL_NAME_TABLE_FUNC_NOWAIT` を作成して `SCROLL_NAME_TABLE_FUNC_NOWAIT_SELECTED` で実行時に選択するようにしました。 
- CLI ヘルプを `VDP WAITの設定 (0=YES, 1=PARTIAL)` に更新し、`CONFIG_VDP_WAIT` のストレージ/設定メニュー項目を削除して個別ジャンプラベルや古い参照を置換しました。 

### Testing
- 自動化されたユニット/統合テストは実行していません。 
- したがって自動テストの成功/失敗報告はありません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962944ab9dc83248ed14cb167ae1bf0)