### PR TITLE
スクリプト隣の `msx1pq_cli` を優先して検索するように変更

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -547,9 +547,17 @@ def find_msx1pq_cli(path: Path | None) -> Path:
             return path
         raise SystemExit(f"msx1pq_cli not found: {path}")
 
+    script_dir = Path(__file__).resolve().parent
+    for candidate_name in ("msx1pq_cli", "msx1pq_cli.exe"):
+        candidate = script_dir / candidate_name
+        if candidate.is_file():
+            return candidate
+
     resolved = shutil.which("msx1pq_cli")
     if not resolved:
-        raise SystemExit("msx1pq_cli not found in PATH. Provide --msx1pq-cli.")
+        raise SystemExit(
+            "msx1pq_cli not found near script or in PATH. Provide --msx1pq-cli."
+        )
     return Path(resolved)
 
 


### PR DESCRIPTION
### Motivation
- `create_scroll_megarom.py` 実行時に `--msx1pq-cli` が指定されない場合でも、スクリプトと同じフォルダにある `msx1pq_cli`/`msx1pq_cli.exe` を使えるようにするため。 

### Description
- `find_msx1pq_cli` にスクリプトのディレクトリ (`Path(__file__).resolve().parent`) を探索し `msx1pq_cli` と `msx1pq_cli.exe` を順にチェックするローカル検索を追加した。  
- 指定パスが存在しない場合の既存のエラーは維持し、PATH にも見つからない場合のエラーメッセージをローカル検索を明示する文に更新した。  
- 変更は `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` に適用している。 

### Testing
- 自動テストは実行しておらず、`tests/test_msx1pq_cli.py` 等のテストは未実行である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963592c6dbc8324a7fb2a3a8b014bd1)