### PR TITLE
`nearest_palette_index` を `msxutils` に移動して再利用

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
@@ -46,6 +46,8 @@ __all__ = [
     "enable_turbor_high_speed_macro",
     "parse_color",
     "BASIC_COLORS_MSX1",
+    "palette_distance",
+    "nearest_palette_index",
     "quantize_msx1_image_two_colors",
 ]
 P = ParamSpec("P")
@@ -100,6 +102,12 @@ BASIC_COLORS_MSX1 = [
     (204, 204, 204),
     (255, 255, 255),
 ]
+
+
+def palette_distance(idx_a: int, idx_b: int) -> int:
+    ra, ga, ba = BASIC_COLORS_MSX1[idx_a]
+    rb, gb, bb = BASIC_COLORS_MSX1[idx_b]
+    return (ra - rb) ** 2 + (ga - gb) ** 2 + (ba - bb) ** 2
 
 
 def parse_color(text: str) -> tuple[int, int, int]:
@@ -292,6 +300,11 @@ def _nearest_palette_index(rgb: tuple[int, int, int]) -> int:
             best_idx = idx
             best_dist = dist
     return best_idx
+
+
+def nearest_palette_index(rgb: Sequence[int]) -> int:
+    """Return the closest MSX1 palette index (0-based) for an RGB triple."""
+    return _nearest_palette_index((int(rgb[0]), int(rgb[1]), int(rgb[2])))
 
 
 def _best_palette_pair(

--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -132,8 +132,8 @@ from mmsxxasmhelper.msxutils import (
     set_screen_display_macro,
     set_screen_display_status_flag_macro,
     quantize_msx1_image_two_colors,
-    BASIC_COLORS_MSX1,
     parse_color,
+    nearest_palette_index,
 )
 from mmsxxasmhelper.config_scene import (
     Screen0ConfigEntry,
@@ -625,26 +625,6 @@ def run_python_quantize(prepared_image: Image.Image, output_path: Path) -> Path:
     quantized = quantize_msx1_image_two_colors(prepared_image)
     quantized.save(output_path)
     return output_path
-
-
-def nearest_palette_index(rgb: Sequence[int]) -> int:
-    """Return the closest MSX1 palette index (0-based) for an RGB triple."""
-    r, g, b = rgb
-    best_idx = 0
-    best_dist = float("inf")
-    for idx, (pr, pg, pb) in enumerate(BASIC_COLORS_MSX1):
-        dist = (r - pr) ** 2 + (g - pg) ** 2 + (b - pb) ** 2
-        if dist < best_dist:
-            best_dist = dist
-            best_idx = idx
-
-    return best_idx
-
-
-def palette_distance(idx_a: int, idx_b: int) -> int:
-    ra, ga, ba = BASIC_COLORS_MSX1[idx_a]
-    rb, gb, bb = BASIC_COLORS_MSX1[idx_b]
-    return (ra - rb) ** 2 + (ga - gb) ** 2 + (ba - bb) ** 2
 
 
 def restrict_two_colors(indices: list[int]) -> list[int]:


### PR DESCRIPTION
### Motivation
- `nearest_palette_index` のロジックを共通ユーティリティに移して重複をなくすため。 
- 他モジュールから同関数を再利用できるようにして保守性を向上させるため。 
- 以前に `palette_distance` を共通化した流れに合わせて色関連ユーティリティを整理するため。 

### Description
- `pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py` に `nearest_palette_index` を追加し `__all__` でエクスポートしました。 
- `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` からローカル定義の `nearest_palette_index` と重複する `palette_distance` 定義を削除し、`nearest_palette_index` を `mmsxxasmhelper.msxutils` からインポートするよう変更しました。 
- `create_scroll_megarom.py` の不要になった `BASIC_COLORS_MSX1` の直接インポートを削除しました。 
- 変更対象ファイルは `pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py` と `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` です。 

### Testing
- 自動化されたテストは実行していません。 
- 変更は静的にインポート先の呼び出し箇所で参照されるよう更新済みです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696367fb425c832485ebbc689a638ce6)