### PR TITLE
SCREEN0 用：￥文字パターンを／に差し替えるマクロを追加

### DIFF
--- a/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
+++ b/pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py
@@ -28,6 +28,7 @@ __all__ = [
     "write_text_with_cursor_macro",
     "write_text_with_cursor_macro_with_bios",
     "set_screen_colors_macro",
+    "replace_screen0_yen_with_slash_macro",
     "enaslt_macro",
     "ldirvm_macro",
     # "set_palette_macro",
@@ -553,6 +554,25 @@ def set_text_cursor_macro(b: Block, x: int, y: int) -> None:
     LD.H_n8(b, (x + 1) & 0xFF)
     LD.L_n8(b, (y + 1) & 0xFF)
     CALL(b, POSIT)
+
+
+def replace_screen0_yen_with_slash_macro(b: Block, *, pattern_table: int = 0x0000) -> None:
+    """SCREEN0 で "￥"(0x5C) の文字パターンを "／" に差し替えるマクロ。
+
+    パターンジェネレータテーブルの先頭アドレスを ``pattern_table`` に指定する。
+    SCREEN0 のデフォルトは 0x0000。
+
+    レジスタ変更: A, HL
+    """
+    yen_char_code = 0x5C
+    slash_pattern = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80]
+
+    LD.HL_n16(b, (pattern_table + yen_char_code * 8) & 0xFFFF)
+    _set_vram_write(b)
+    for byte in slash_pattern:
+        LD.A_n8(b, byte)
+        OUT(b, VDP_DATA)
+        NOP(b, 2)
 
 
 def write_text_with_cursor_macro_with_bios(b: Block, text: str, x: int, y: int) -> None:


### PR DESCRIPTION
### Motivation
- SCREEN0 の文字パターンで表示される「￥」(0x5C)を「／」のグリフに置き換える必要があったため、VRAM のパターンジェネレータを書き換えるユーティリティを追加しました。 
- SCREEN0 はパターンテーブルを直接書き換えられるため、ランタイムで簡単に字形を差し替えられることが目的です。 

### Description
- `pyutils/mmsxxasmhelper/src/mmsxxasmhelper/msxutils.py` に `replace_screen0_yen_with_slash_macro` を追加し `__all__` に公開しました。 
- マクロは `pattern_table + 0x5C * 8` から始まるパターンジェネレータ領域に対してスラッシュ用の 8 バイトパターンを書き込み、`_set_vram_write` と `OUT(..., VDP_DATA)` を用いて VRAM に反映します。 
- マクロはレジスタ `A` と `HL` を使用・変更することをドキュメントに明記しています。 

### Testing
- 自動化されたテストは実行していません。 
- 変更は該当ファイルへ適用・コミット済みで、構文エラーは発生していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69636c1f5fe48324b3d56b6f2c7bbc4b)