### PR TITLE
create_scroll_megarom 用の Nuitka ビルダを追加

### DIFF
--- a/pyutils/sc2_viewer_rom/make_create_scroll_megarom_exe.py
+++ b/pyutils/sc2_viewer_rom/make_create_scroll_megarom_exe.py
@@ -1,0 +1,53 @@
+"""Utilities to bundle create_scroll_megarom into a single-file executable with Nuitka."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def build_executable(output_dir: Path) -> None:
+    """Compile ``create_scroll_megarom.py`` into a one-file executable via Nuitka."""
+    script_dir = Path(__file__).resolve().parent
+    target = script_dir / "src" / "create_scroll_megarom.py"
+    if not target.exists():
+        raise FileNotFoundError(f"Cannot find source script: {target}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "nuitka",
+        "--onefile",
+        "--remove-output",
+        "--assume-yes-for-downloads",
+        f"--output-dir={output_dir}",
+        str(target),
+    ]
+
+    print("Running Nuitka:")
+    print(" ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build a standalone executable for create_scroll_megarom using Nuitka",
+    )
+    default_output = Path(__file__).resolve().parent / "dist"
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=default_output,
+        help=f"Directory for the generated executable (default: {default_output})",
+    )
+    args = parser.parse_args()
+
+    build_executable(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- `src/create_scroll_megarom.py` を単一ファイルの実行可能にビルドするためのユーティリティが必要で、既存の他スクリプトと同様の扱いにするため。

### Description
- 新規ファイル `pyutils/sc2_viewer_rom/make_create_scroll_megarom_exe.py` を追加し、`src/create_scroll_megarom.py` を対象にビルドする機能を実装しました。
- `build_executable` 関数で出力ディレクトリを作成し、`sys.executable -m nuitka --onefile --remove-output --assume-yes-for-downloads --output-dir=...` で Nuitka を実行します。
- `main()` は `--output-dir` 引数を受け取り、デフォルトはスクリプトディレクトリ内の `dist` を使用します。

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963752ba69883248cb2daa849a05b87)