### PR TITLE
上下キーで手動入力した際に自動スクロール方向を即時更新

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -1781,6 +1781,8 @@ def build_boot_bank(
     LD.A_n8(b, 1)
     LD.mn16_A(b, ADDR.SKIP_AUTO_SCROLL)
     RESET_AUTO_SCROLL_TURN_COUNTERS_FUNC.call(b)
+    LD.A_n8(b, 0xFF)
+    LD.mn16_A(b, ADDR.AUTO_SCROLL_DIR)
 
     # SHIFT 押下時は 8 行スクロールして全体を再描画
     LD.A_mn16(b, ADDR.INPUT_HOLD)
@@ -1829,6 +1831,8 @@ def build_boot_bank(
     LD.A_n8(b, 1)
     LD.mn16_A(b, ADDR.SKIP_AUTO_SCROLL)
     RESET_AUTO_SCROLL_TURN_COUNTERS_FUNC.call(b)
+    LD.A_n8(b, 1)
+    LD.mn16_A(b, ADDR.AUTO_SCROLL_DIR)
 
     # SHIFT 押下時は 8 行スクロールして全体を再描画
     LD.A_mn16(b, ADDR.INPUT_HOLD)


### PR DESCRIPTION
### Motivation

- 手動で上下キーを押したときに、自動スクロールの方向がキーの方向に即座に切り替わるようにするため。 
- SHIFT 有無にかかわらず同じ挙動にしてユーザー操作の意図を反映させるため。 
- 自動スクロールの折返しや端待ちロジックと整合させ、予期しない方向変化を防ぐため。 

### Description

- `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` の `build_boot_bank` 内メインループの上下入力処理に `ADDR.AUTO_SCROLL_DIR` への書き込みを追加しました。 
- 上キー検出直後に `LD.A_n8(b, 0xFF)` と `LD.mn16_A(b, ADDR.AUTO_SCROLL_DIR)` を挿入して上方向を設定し、下キー検出直後に `LD.A_n8(b, 1)` と `LD.mn16_A(b, ADDR.AUTO_SCROLL_DIR)` を挿入して下方向を設定しています。 
- `ADDR.SKIP_AUTO_SCROLL` の設定や `RESET_AUTO_SCROLL_TURN_COUNTERS_FUNC` の呼び出しなど既存処理は維持しています。 

### Testing

- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696381be8c0483248ae71c4a008045a8)