### PR TITLE
`--input-each (-ie)` オプションを追加して列挙ファイルを個別画像扱いに変更

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -183,6 +183,13 @@ class Messages:
         }
 
     @_localized
+    def input_each_help(cls) -> dict[str, str]:
+        return {
+            "jp": "--input-each に列挙したファイルは連結せず、各ファイルを別画像として扱う",
+            "en": "Treat each --input-each file as a separate image without stacking.",
+        }
+
+    @_localized
     def debug_image_index_help(cls) -> dict[str, str]:
         return {
             "jp": "--use-debug-image 時に埋め込む番号",
@@ -435,6 +442,16 @@ def parse_args() -> argparse.Namespace:
         action="append",
         required=True,
         help=Messages.input_help(),
+    )
+    parser.add_argument(
+        "-ie",
+        "--input-each",
+        dest="input_each",
+        metavar="PNG",
+        type=Path,
+        nargs="+",
+        action="append",
+        help=Messages.input_each_help(),
     )
     parser.add_argument(
         "--use-debug-image",
@@ -2533,7 +2550,9 @@ def main() -> None:
     input_format_counter: Counter[str] = Counter()
     total_input_images = 0
 
-    input_groups: list[list[Path]] = [list(group) for group in args.input]
+    input_groups = [list(group) for group in args.input]
+    if args.input_each:
+        input_groups.extend([path] for group in args.input_each for path in group)
     prepared_groups: list[tuple[str, list[tuple[str, Image.Image, float]]]] = []
     image_data_list: list[ImageData] = []
     rom: bytes


### PR DESCRIPTION
### Motivation
- 列挙したファイルを連結せずに各ファイルを単独のスクロール入力（個別画像）として扱えるようにするため。 
- 既存の `--input` グループ化挙動はそのまま維持するため。 

### Description
- `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` に `-ie` 短縮オプション付きの `--input-each` 引数を追加し `dest='input_each'` として受け取るようにしました。 
- ヘルプ文言関連で `Messages.each_input_help` を `Messages.input_each_help` にリネームしてローカライズ済みメッセージを更新しました。 
- 入力グループ構築で既存の `--input` 振る舞いはそのままに、`--input-each` 指定分を単独のグループとして `input_groups.extend([path] for group in args.input_each for path in group)` で追加するように変更しました。 

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69638af31af88324b5f1e84e50d8ace9)