### PR TITLE
スクロールメガROM CLI の短縮フラグ名を修正（`-bg`, `-pqcli`）

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -453,27 +453,32 @@ def parse_args() -> argparse.Namespace:
         help=Messages.output_help(),
     )
     parser.add_argument(
+        "-bg",
         "--background",
         type=str,
         default="#000000",
         help=Messages.background_help(),
     )
     parser.add_argument(
+        "-pqcli",
         "--msx1pq-cli",
         type=Path,
         help=Messages.msx1pq_cli_help(),
     )
     parser.add_argument(
+        "-W",
         "--workdir",
         type=Path,
         help=Messages.workdir_help(),
     )
     parser.add_argument(
+        "-N",
         "--no-cache",
         action="store_true",
         help=Messages.no_cache_help(),
     )
     parser.add_argument(
+        "-F",
         "--fill-byte",
         type=int_from_str,
         default=0xFF,
@@ -522,6 +527,7 @@ def parse_args() -> argparse.Namespace:
         help=Messages.start_at_help(),
     )
     parser.add_argument(
+        "-sao",
         "--start-at-override",
         nargs="+",
         choices=["top", "bottom"],
@@ -538,18 +544,21 @@ def parse_args() -> argparse.Namespace:
         help=Messages.debug_build_help(),
     )
     parser.add_argument(
+        "-vwn",
         "--vdp-wait-for-name-table",
         choices=["PARTIAL", "NOWAIT"],
         default="NOWAIT",
         help=Messages.vdp_wait_name_help(),
     )
     parser.add_argument(
+        "-vwp",
         "--vdp-wait-for-pattern-gen",
         choices=["PARTIAL", "NOWAIT"],
         default="NOWAIT",
         help=Messages.vdp_wait_pattern_help(),
     )
     parser.add_argument(
+        "-vwc",
         "--vdp-wait-for-color-table",
         choices=["PARTIAL", "NOWAIT"],
         default="NOWAIT",


### PR DESCRIPTION
### Motivation
- 長いオプション名の入力負担を軽減するために短縮フラグを用意しており、一部の短縮名を指摘に合わせて統一する必要があったと想定しています。

### Description
- `pyutils/sc2_viewer_rom/src/create_scroll_megarom.py` において `--background` の短縮フラグを `-B` から `-bg` に変更しました。
- 同ファイルで `--msx1pq-cli` の短縮フラグを `-M` から `-pqcli` に変更しました。
- 既に追加済みの他の短縮フラグ（`-W`/`-N`/`-F`/`-sao`/`-vwn`/`-vwp`/`-vwc`）やオプションの振る舞いは変更していません。

### Testing
- 自動テスト（CI/ユニットテスト）は実行していません。
- 自動テストの結果は無く、テストは未実行です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69638b069e1483249908eb7cb94a32fe)