### PR TITLE
ネームテーブル用スクロール行を別管理に変更

### DIFF
--- a/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
+++ b/pyutils/sc2_viewer_rom/src/create_scroll_megarom.py
@@ -692,6 +692,8 @@ class ADDR:
         madd("CURRENT_IMAGE_COLOR_ADDRESS_ADDR", 2, description="カラーパターンの先頭アドレス"))
     CURRENT_SCROLL_ROW = (
         madd("CURRENT_SCROLL_ROW", 2, description="スクロール位置"))
+    CURRENT_NAME_TABLE_ROW = (
+        madd("CURRENT_NAME_TABLE_ROW", 1, description="ネームテーブル用スクロール位置"))
 
     INPUT_HOLD = madd("INPUT_HOLD", 1, description="現在押されている全入力")
     INPUT_TRG = madd("INPUT_TRG", 1, description="今回新しく押された入力")
@@ -1233,6 +1235,8 @@ def build_update_image_display_func(
         LD.mn16_HL(block, ADDR.CURRENT_SCROLL_ROW)
 
         block.label("_INIT_POS_DONE")
+        LD.A_mn16(block, ADDR.CURRENT_SCROLL_ROW)
+        LD.mn16_A(block, ADDR.CURRENT_NAME_TABLE_ROW)
 
         # 4. VRAM 描画実行
         DRAW_SCROLL_VIEW_FUNC.call(block)
@@ -1856,6 +1860,9 @@ def build_boot_bank(
     JR_Z(b, "CHECK_DOWN")
     DEC.HL(b)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
+    LD.A_mn16(b, ADDR.CURRENT_NAME_TABLE_ROW)
+    DEC.A(b)
+    LD.mn16_A(b, ADDR.CURRENT_NAME_TABLE_ROW)
 
     # --- 追記：方向フラグ(0=上)をセット ---
     XOR.A(b)
@@ -1934,6 +1941,9 @@ def build_boot_bank(
     LD.HL_mn16(b, ADDR.CURRENT_SCROLL_ROW)
     INC.HL(b)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
+    LD.A_mn16(b, ADDR.CURRENT_NAME_TABLE_ROW)
+    INC.A(b)
+    LD.mn16_A(b, ADDR.CURRENT_NAME_TABLE_ROW)
 
     # --- 追記：方向フラグ(1=下)をセット ---
     LD.A_n8(b, 1)
@@ -1946,7 +1956,7 @@ def build_boot_bank(
 
     b.label("DO_UPDATE_SCROLL")
     # 1. 名前テーブルをずらす (TABLE_MOD24 を使用)
-    LD.A_mn16(b, ADDR.CURRENT_SCROLL_ROW)
+    LD.A_mn16(b, ADDR.CURRENT_NAME_TABLE_ROW)
     LD.L_A(b)
     LD.H_n8(b, 0)
     LD.DE_label(b, "TABLE_MOD24")
@@ -2056,6 +2066,9 @@ def build_boot_bank(
     JP_Z(b, "AUTO_SCROLL_EDGE_TOP")
     DEC.HL(b)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
+    LD.A_mn16(b, ADDR.CURRENT_NAME_TABLE_ROW)
+    DEC.A(b)
+    LD.mn16_A(b, ADDR.CURRENT_NAME_TABLE_ROW)
     # --- 自動スクロール時の方向フラグ(0=上)をセット ---
     XOR.A(b)
     LD.mn16_A(b, ADDR.SCROLL_DIRECTION)
@@ -2105,6 +2118,9 @@ def build_boot_bank(
     LD.HL_mn16(b, ADDR.CURRENT_SCROLL_ROW)
     INC.HL(b)
     LD.mn16_HL(b, ADDR.CURRENT_SCROLL_ROW)
+    LD.A_mn16(b, ADDR.CURRENT_NAME_TABLE_ROW)
+    INC.A(b)
+    LD.mn16_A(b, ADDR.CURRENT_NAME_TABLE_ROW)
     # --- 自動スクロール時の方向フラグ(1=下)をセット ---
     LD.A_n8(b, 1)
     LD.mn16_A(b, ADDR.SCROLL_DIRECTION)


### PR DESCRIPTION
### Motivation
- `SHIFT`での8行スクロール後にネームテーブルの状態がずれる問題を解消するため、描画位置とネームテーブル位置を明確に分離する必要がありました。 
- 単発スクロールや自動スクロールでは増分更新でネームテーブルを正しく反映させたいという狙いがあります。 
- 全体再描画（SHIFT）時の即時ネームテーブル読み出しに依存せず、管理変数で一貫性を保つ方針としました。 

### Description
- `ADDR`に`CURRENT_NAME_TABLE_ROW`を追加してネームテーブル用のスクロール位置を別変数で管理するようにしました（`pyutils/sc2_viewer_rom/src/create_scroll_megarom.py`）。
- 画像初期表示処理で`CURRENT_SCROLL_ROW`の値を`CURRENT_NAME_TABLE_ROW`へコピーして初期化するように変更しました（`build_update_image_display_func`内での初期化）。
- 単発スクロール（上/下）と自動スクロール処理で`CURRENT_NAME_TABLE_ROW`を増減するようにし、`DO_UPDATE_SCROLL`が`CURRENT_NAME_TABLE_ROW`を参照するように切り替えました。 
- SHIFT（8行全体再描画）パスからネームテーブルの即時読み出し/更新を除去し、トラッキング変数で増分更新を行うようにしました。 

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696389eb67fc8324a3c087e6b2afe1ea)