### PR TITLE
README にサブモジュール初期化手順を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ It should also work on Mac if built with Xcode.
 2.  Copy the plugin file to the common plugin folder of After Effects / Premiere PRO.
     - Windows: `C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\`
 
+## Repository Setup
+
+This repository uses git submodules for Python utilities under `pyutils`. After cloning, initialize the submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
 ## How to Use
 
 1.  Launch After Effects.

--- a/README_ja.md
+++ b/README_ja.md
@@ -44,6 +44,14 @@ Mac でも Xcode でビルドすれば動作する想定です。
 2.  After Effects / Premiere PRO の共通プラグインフォルダにプラグインファイルをコピーします。
     - Windows: `C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\`
 
+## リポジトリのセットアップ
+
+このリポジトリでは `pyutils` を git submodule として管理しています。クローン後に submodule を初期化してください。
+
+```bash
+git submodule update --init --recursive
+```
+
 ## 使用方法
 
 1.  After Effectsを起動します。
@@ -117,6 +125,5 @@ CLI の挙動確認用テストは Windows 環境で、既にビルド済みの 
 * CLI版にはPNGエンコーダ/デコーダライブラリ「lodepng」を使用しています。
   * https://github.com/lvandeve/lodepng/
   * [THIRD_PARTY_LICENSES.txt](THIRD_PARTY_LICENSES.txt)
-
 
 


### PR DESCRIPTION
### Motivation

- サブモジュールを移動したため、クローン後にサブモジュールを初期化する手順を README に明記する必要がありました。 
- リポジトリ内の Python ユーティリティ `pyutils` がサブモジュール管理されていることを明示して利用者のセットアップを簡素化します。

### Description

- 英語版 `README.md` に `Repository Setup` セクションを追加してサブモジュール初期化手順を記載しました。 
- 日本語版 `README_ja.md` に `リポジトリのセットアップ` セクションを追加して同等の手順を追記しました。 
- クローン後に実行するコマンドとして `git submodule update --init --recursive` を明示的に示しています。 

### Testing

- ドキュメント変更のため自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696383f963f083248dc4b1ac86ca1e3a)